### PR TITLE
[WIP] Create Fractional MarketWrapper

### DIFF
--- a/contracts/external/fractional/ERC721TokenVault.sol
+++ b/contracts/external/fractional/ERC721TokenVault.sol
@@ -22,7 +22,7 @@ contract TokenVault is ERC20Upgradeable, ERC721HolderUpgradeable {
     /// -----------------------------------
 
     /// @notice weth address
-    address public constant weth = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+    address public weth = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
 
     /// -----------------------------------
     /// -------- TOKEN INFORMATION --------
@@ -106,6 +106,11 @@ contract TokenVault is ERC20Upgradeable, ERC721HolderUpgradeable {
 
     constructor(address _settings) {
         settings = _settings;
+    }
+
+    //NOTE: Added just for locally testing with partyBid
+    function setWeth(address _weth) external {
+        weth = _weth;
     }
 
     function initialize(address _curator, address _token, uint256 _id, uint256 _supply, uint256 _listPrice, uint256 _fee, string memory _name, string memory _symbol) external initializer {

--- a/contracts/external/interfaces/IERC721TokenVault.sol
+++ b/contracts/external/interfaces/IERC721TokenVault.sol
@@ -1,0 +1,27 @@
+//SPDX-License-Identifier: MIT
+pragma solidity 0.8.5;
+
+interface IERC721TokenVault {  
+  // Returns value corresponding to the enum: State { inactive, live, ended, redeemed }
+  function auctionState() external view returns (uint8);
+
+  function auctionEnd() external view returns (uint256);
+
+  function token() external view returns (address);
+
+  function id() external view returns (uint256);
+
+  function reservePrice() external view returns (uint256);
+
+  function totalSupply() external view returns (uint256);
+
+  function votingTokens() external view returns (uint256);
+
+  function settings() external view returns (address);
+
+  function livePrice() external view returns (uint256);
+
+  function winning() external view returns (address);
+
+  function end() external;
+}

--- a/contracts/external/interfaces/IERC721VaultFactory.sol
+++ b/contracts/external/interfaces/IERC721VaultFactory.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.5;
 
 interface IERC721VaultFactory {
     /// @notice the mapping of vault number to vault address
-    function vaults(uint256) external returns (address);
+    function vaults(uint256) external view returns (address);
 
     /// @notice the function to mint a new vault
     /// @param _name the desired name of the vault

--- a/contracts/external/interfaces/IFractionalSettings.sol
+++ b/contracts/external/interfaces/IFractionalSettings.sol
@@ -1,0 +1,8 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.5;
+
+interface IFractionalSettings {
+    function minBidIncrease() external view returns(uint256);
+
+    function minVotePercentage() external view returns(uint256);
+}

--- a/contracts/market-wrapper/FractionalMarketWrapper.sol
+++ b/contracts/market-wrapper/FractionalMarketWrapper.sol
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.5;
+
+// ============ External Imports ============
+import {IERC721VaultFactory} from "../external/interfaces/IERC721VaultFactory.sol";
+import {IERC721TokenVault} from "../external/interfaces/IERC721TokenVault.sol";
+import {IFractionalSettings} from "../external/interfaces/IFractionalSettings.sol";
+
+// ============ Internal Imports ============
+import {IMarketWrapper} from "./IMarketWrapper.sol";
+
+/**
+ * @title FractionalMarketWrapper
+ * @author Apoorv Lathey
+ * @notice MarketWrapper contract implementing IMarketWrapper interface
+ * according to the logic of Fractional's Token Vaults
+ */
+contract FractionalMarketWrapper is IMarketWrapper {
+    // ============ Public Immutables ============
+
+    IERC721VaultFactory public immutable market;
+
+    // ======== Constructor =========
+
+    constructor(address _fractionalERC721VaultFactory) {
+        market = IERC721VaultFactory(_fractionalERC721VaultFactory);
+    }
+
+    // ======== External Functions =========
+
+    /**
+     * @notice Determine whether there is an existing auction
+     * for this token on the market
+     * @return TRUE if the auction exists
+     */
+    function auctionExists(uint256 auctionId) public view returns (bool) {
+        IERC721TokenVault tokenVault = IERC721TokenVault(
+            market.vaults(auctionId)
+        );
+        uint8 auctionState = tokenVault.auctionState();
+        if (auctionState == 0) {
+            // line 319 of ERC721TokenVault
+            IFractionalSettings settings = IFractionalSettings(
+                tokenVault.settings()
+            );
+            uint256 minVotePercentage = settings.minVotePercentage();
+            uint256 totalSupply = tokenVault.totalSupply();
+            uint256 votingTokens = tokenVault.votingTokens();
+
+            // auction can be initiated via start() in ERC721TokenVault,
+            // if enough votes reached
+            return (votingTokens * 1000 >= minVotePercentage * totalSupply);
+        } else if (auctionState == 1) {
+            uint256 auctionEnd = tokenVault.auctionEnd();
+            return block.timestamp < auctionEnd;
+        }
+
+        return false;
+    }
+
+    /**
+     * @notice Determine whether the given auctionId is
+     * an auction for the tokenId + nftContract
+     * @return TRUE if the auctionId matches the tokenId + nftContract
+     */
+    function auctionIdMatchesToken(
+        uint256 auctionId,
+        address nftContract,
+        uint256 tokenId
+    ) public view override returns (bool) {
+        IERC721TokenVault tokenVault = IERC721TokenVault(
+            market.vaults(auctionId)
+        );
+        address _nftContract = tokenVault.token();
+        uint256 _tokenId = tokenVault.id();
+        return
+            _nftContract == nftContract &&
+            _tokenId == tokenId &&
+            auctionExists(auctionId);
+    }
+
+    /**
+     * @notice Calculate the minimum next bid for this auction
+     * @return minimum bid amount
+     */
+    function getMinimumBid(uint256 auctionId)
+        external
+        view
+        override
+        returns (uint256)
+    {
+        IERC721TokenVault tokenVault = IERC721TokenVault(
+            market.vaults(auctionId)
+        );
+        uint8 auctionState = tokenVault.auctionState();
+        if (auctionState == 0) {
+            return tokenVault.reservePrice();
+        } else {
+            IFractionalSettings settings = IFractionalSettings(
+                tokenVault.settings()
+            );
+            uint256 livePrice = tokenVault.livePrice();
+            uint256 increase = settings.minBidIncrease() + 1000;
+            // line 334 of ERC721TokenVault
+            return (livePrice * increase) / 1000;
+        }
+    }
+
+    /**
+     * @notice Query the current highest bidder for this auction
+     * @return highest bidder
+     */
+    function getCurrentHighestBidder(uint256 auctionId)
+        external
+        view
+        override
+        returns (address)
+    {
+        IERC721TokenVault tokenVault = IERC721TokenVault(
+            market.vaults(auctionId)
+        );
+        return tokenVault.winning();
+    }
+
+    /**
+     * @notice Submit bid to Market contract
+     */
+    function bid(uint256 auctionId, uint256 bidAmount) external override {
+        IERC721TokenVault tokenVault = IERC721TokenVault(
+            market.vaults(auctionId)
+        );
+        uint8 auctionState = tokenVault.auctionState();
+        if (auctionState == 0) {
+            // line 316 of ERC721TokenVault, start() function
+            (bool success, bytes memory returnData) = address(tokenVault).call{
+                value: bidAmount
+            }(abi.encodeWithSignature("start()"));
+            require(success, string(returnData));
+        } else {
+            // line 331 of ERC721TokenVault, bid() function
+            (bool success, bytes memory returnData) = address(tokenVault).call{
+                value: bidAmount
+            }(abi.encodeWithSignature("bid()"));
+            require(success, string(returnData));
+        }
+    }
+
+    /**
+     * @notice Determine whether the auction has been finalized
+     * @return TRUE if the auction has been finalized
+     */
+    function isFinalized(uint256 auctionId)
+        external
+        view
+        override
+        returns (bool)
+    {
+        IERC721TokenVault tokenVault = IERC721TokenVault(
+            market.vaults(auctionId)
+        );
+        uint8 auctionState = tokenVault.auctionState();
+        // auction is considered finalized if
+        // 1. the voters backed off now, so the auction can't be initiated
+        // 2. the auction got ended
+        // 3. the vault got redeemed (hence, no bids were placed)
+
+        if (auctionState == 0) {
+            // line 319 of ERC721TokenVault
+            IFractionalSettings settings = IFractionalSettings(
+                tokenVault.settings()
+            );
+            uint256 minVotePercentage = settings.minVotePercentage();
+            uint256 totalSupply = tokenVault.totalSupply();
+            uint256 votingTokens = tokenVault.votingTokens();
+
+            // auction **cannot** be initiated via start() in ERC721TokenVault,
+            return (votingTokens * 1000 < minVotePercentage * totalSupply);
+        }
+
+        return auctionState == 2 || auctionState == 3;
+    }
+
+    /**
+     * @notice Finalize the results of the auction
+     * @dev gets called when block.timestamp >= auctionEnd
+     */
+    function finalize(uint256 auctionId) external override {
+        IERC721TokenVault tokenVault = IERC721TokenVault(
+            market.vaults(auctionId)
+        );
+        tokenVault.end();
+    }
+}

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -4,9 +4,9 @@ require('@nomiclabs/hardhat-etherscan');
 require('@openzeppelin/hardhat-upgrades');
 const dotenv = require('dotenv');
 dotenv.config();
-const {verify} = require("./deploy/verify");
+const { verify } = require('./deploy/verify');
 
-task("verify-contracts", "Verifies the core contracts").setAction(verify);
+task('verify-contracts', 'Verifies the core contracts').setAction(verify);
 
 /**
  * @type import('hardhat/config').HardhatUserConfig
@@ -26,23 +26,19 @@ module.exports = {
       {
         version: '0.7.5',
         settings: {
-          "optimizer": {
-            "enabled": true,
-            "runs": 1337
+          optimizer: {
+            enabled: true,
+            runs: 1337,
           },
-          "outputSelection": {
-            "*": {
-              "*": [
-                "evm.bytecode",
-                "evm.deployedBytecode",
-                "abi"
-              ]
-            }
+          outputSelection: {
+            '*': {
+              '*': ['evm.bytecode', 'evm.deployedBytecode', 'abi'],
+            },
           },
-          "metadata": {
-            "useLiteralContent": true
+          metadata: {
+            useLiteralContent: true,
           },
-          "libraries": {}
+          libraries: {},
         },
       },
       {
@@ -62,7 +58,7 @@ module.exports = {
             runs: 999999,
           },
         },
-      }
+      },
     ],
   },
 
@@ -71,7 +67,7 @@ module.exports = {
   },
 
   etherscan: {
-    apiKey: process.env.ETHERSCAN_API_KEY
+    apiKey: process.env.ETHERSCAN_API_KEY,
   },
 
   networks: {
@@ -84,6 +80,9 @@ module.exports = {
     },
     mainnet: {
       url: `https://mainnet.infura.io/v3/${process.env.INFURA_PROJECT_ID}`,
-    }
+    },
+  },
+  mocha: {
+    timeout: 200000,
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -184,34 +184,62 @@
       }
     },
     "@ethereumjs/block": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/block/-/block-3.3.0.tgz",
-      "integrity": "sha512-WoefY9Rs4W8vZTxG9qwntAlV61xsSv0NPoXmHO7x3SH16dwJQtU15YvahPCz4HEEXbu7GgGgNgu0pv8JY7VauA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/block/-/block-3.4.0.tgz",
+      "integrity": "sha512-umKAoTX32yXzErpIksPHodFc/5y8bmZMnOl6hWy5Vd8xId4+HKFUOyEiN16Y97zMwFRysRpcrR6wBejfqc6Bmg==",
       "dev": true,
       "requires": {
-        "@ethereumjs/common": "^2.3.0",
-        "@ethereumjs/tx": "^3.2.0",
-        "ethereumjs-util": "^7.0.10",
+        "@ethereumjs/common": "^2.4.0",
+        "@ethereumjs/tx": "^3.3.0",
+        "ethereumjs-util": "^7.1.0",
         "merkle-patricia-tree": "^4.2.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+          "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
+          "dev": true
+        },
+        "ethereumjs-util": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.0.tgz",
+          "integrity": "sha512-kR+vhu++mUDARrsMMhsjjzPduRVAeundLGXucGRHF3B4oEltOUspfgCVco4kckucj3FMlLaZHUl9n7/kdmr6Tw==",
+          "dev": true,
+          "requires": {
+            "@types/bn.js": "^5.1.0",
+            "bn.js": "^5.1.2",
+            "create-hash": "^1.1.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "0.1.6",
+            "rlp": "^2.2.4"
+          }
+        }
       }
     },
     "@ethereumjs/blockchain": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/blockchain/-/blockchain-5.3.0.tgz",
-      "integrity": "sha512-B0Y5QDZcRDQISPilv3m8nzk97QmC98DnSE9WxzGpCxfef22Mw7xhwGipci5Iy0dVC2Np2Cr5d3F6bHAR7+yVmQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/blockchain/-/blockchain-5.4.0.tgz",
+      "integrity": "sha512-wAuKLaew6PL52kH8YPXO7PbjjKV12jivRSyHQehkESw4slSLLfYA6Jv7n5YxyT2ajD7KNMPVh7oyF/MU6HcOvg==",
       "dev": true,
       "requires": {
-        "@ethereumjs/block": "^3.3.0",
-        "@ethereumjs/common": "^2.3.0",
+        "@ethereumjs/block": "^3.4.0",
+        "@ethereumjs/common": "^2.4.0",
         "@ethereumjs/ethash": "^1.0.0",
         "debug": "^2.2.0",
-        "ethereumjs-util": "^7.0.10",
+        "ethereumjs-util": "^7.1.0",
         "level-mem": "^5.0.1",
         "lru-cache": "^5.1.1",
         "rlp": "^2.2.4",
         "semaphore-async-await": "^1.5.1"
       },
       "dependencies": {
+        "bn.js": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+          "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
+          "dev": true
+        },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -219,6 +247,20 @@
           "dev": true,
           "requires": {
             "ms": "2.0.0"
+          }
+        },
+        "ethereumjs-util": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.0.tgz",
+          "integrity": "sha512-kR+vhu++mUDARrsMMhsjjzPduRVAeundLGXucGRHF3B4oEltOUspfgCVco4kckucj3FMlLaZHUl9n7/kdmr6Tw==",
+          "dev": true,
+          "requires": {
+            "@types/bn.js": "^5.1.0",
+            "bn.js": "^5.1.2",
+            "create-hash": "^1.1.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "0.1.6",
+            "rlp": "^2.2.4"
           }
         },
         "lru-cache": {
@@ -245,13 +287,35 @@
       }
     },
     "@ethereumjs/common": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-2.3.1.tgz",
-      "integrity": "sha512-V8hrULExoq0H4HFs3cCmdRGbgmipmlNzak6Xg34nHYfQyqkSdrCuflvYjyWmsNpI8GtrcZhzifAbgX/1C1Cjwg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-2.4.0.tgz",
+      "integrity": "sha512-UdkhFWzWcJCZVsj1O/H8/oqj/0RVYjLc1OhPjBrQdALAkQHpCp8xXI4WLnuGTADqTdJZww0NtgwG+TRPkXt27w==",
       "dev": true,
       "requires": {
         "crc-32": "^1.2.0",
-        "ethereumjs-util": "^7.0.10"
+        "ethereumjs-util": "^7.1.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+          "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
+          "dev": true
+        },
+        "ethereumjs-util": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.0.tgz",
+          "integrity": "sha512-kR+vhu++mUDARrsMMhsjjzPduRVAeundLGXucGRHF3B4oEltOUspfgCVco4kckucj3FMlLaZHUl9n7/kdmr6Tw==",
+          "dev": true,
+          "requires": {
+            "@types/bn.js": "^5.1.0",
+            "bn.js": "^5.1.2",
+            "create-hash": "^1.1.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "0.1.6",
+            "rlp": "^2.2.4"
+          }
+        }
       }
     },
     "@ethereumjs/ethash": {
@@ -278,29 +342,51 @@
       }
     },
     "@ethereumjs/tx": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-3.2.1.tgz",
-      "integrity": "sha512-i9V39OtKvwWos1uVNZxdVhd7zFOyzFLjgt69CoiOY0EmXugS0HjO3uxpLBSglDKFMRriuGqw6ddKEv+RP1UNEw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-3.3.0.tgz",
+      "integrity": "sha512-yTwEj2lVzSMgE6Hjw9Oa1DZks/nKTWM8Wn4ykDNapBPua2f4nXO3qKnni86O6lgDj5fVNRqbDsD0yy7/XNGDEA==",
       "dev": true,
       "requires": {
-        "@ethereumjs/common": "^2.3.1",
-        "ethereumjs-util": "^7.0.10"
+        "@ethereumjs/common": "^2.4.0",
+        "ethereumjs-util": "^7.1.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+          "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
+          "dev": true
+        },
+        "ethereumjs-util": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.0.tgz",
+          "integrity": "sha512-kR+vhu++mUDARrsMMhsjjzPduRVAeundLGXucGRHF3B4oEltOUspfgCVco4kckucj3FMlLaZHUl9n7/kdmr6Tw==",
+          "dev": true,
+          "requires": {
+            "@types/bn.js": "^5.1.0",
+            "bn.js": "^5.1.2",
+            "create-hash": "^1.1.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "0.1.6",
+            "rlp": "^2.2.4"
+          }
+        }
       }
     },
     "@ethereumjs/vm": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/vm/-/vm-5.4.1.tgz",
-      "integrity": "sha512-cpQcg5CtjzXJBn8QNiobaiWckeN/ZQwsDHLYa9df2wBEUvzuEZgFWK48YEXSpx3CnUY9fNT/lgA9CzKdq8HTzQ==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/vm/-/vm-5.5.2.tgz",
+      "integrity": "sha512-AydZ4wfvZAsBuFzs3xVSA2iU0hxhL8anXco3UW3oh9maVC34kTEytOfjHf06LTEfN0MF9LDQ4ciLa7If6ZN/sg==",
       "dev": true,
       "requires": {
-        "@ethereumjs/block": "^3.3.0",
-        "@ethereumjs/blockchain": "^5.3.0",
-        "@ethereumjs/common": "^2.3.1",
-        "@ethereumjs/tx": "^3.2.1",
+        "@ethereumjs/block": "^3.4.0",
+        "@ethereumjs/blockchain": "^5.4.0",
+        "@ethereumjs/common": "^2.4.0",
+        "@ethereumjs/tx": "^3.3.0",
         "async-eventemitter": "^0.2.4",
         "core-js-pure": "^3.0.1",
         "debug": "^2.2.0",
-        "ethereumjs-util": "^7.0.10",
+        "ethereumjs-util": "^7.1.0",
         "functional-red-black-tree": "^1.0.1",
         "mcl-wasm": "^0.7.1",
         "merkle-patricia-tree": "^4.2.0",
@@ -308,6 +394,12 @@
         "util.promisify": "^1.0.1"
       },
       "dependencies": {
+        "bn.js": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+          "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
+          "dev": true
+        },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -315,6 +407,20 @@
           "dev": true,
           "requires": {
             "ms": "2.0.0"
+          }
+        },
+        "ethereumjs-util": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.0.tgz",
+          "integrity": "sha512-kR+vhu++mUDARrsMMhsjjzPduRVAeundLGXucGRHF3B4oEltOUspfgCVco4kckucj3FMlLaZHUl9n7/kdmr6Tw==",
+          "dev": true,
+          "requires": {
+            "@types/bn.js": "^5.1.0",
+            "bn.js": "^5.1.2",
+            "create-hash": "^1.1.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "0.1.6",
+            "rlp": "^2.2.4"
           }
         },
         "ms": {
@@ -393,13 +499,39 @@
       }
     },
     "@ethersproject/basex": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.3.0.tgz",
-      "integrity": "sha512-8J4nS6t/SOnoCgr3DF5WCSRLC5YwTKYpZWJqeyYQLX+86TwPhtzvHXacODzcDII9tWKhVg6g0Bka8JCBWXsCiQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.4.0.tgz",
+      "integrity": "sha512-J07+QCVJ7np2bcpxydFVf/CuYo9mZ7T73Pe7KQY4c1lRlrixMeblauMxHXD0MPwFmUHZIILDNViVkykFBZylbg==",
       "dev": true,
       "requires": {
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/properties": "^5.3.0"
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0"
+      },
+      "dependencies": {
+        "@ethersproject/bytes": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.4.0.tgz",
+          "integrity": "sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.1.tgz",
+          "integrity": "sha512-DZ+bRinnYLPw1yAC64oRl0QyVZj43QeHIhVKfD/+YwSz4wsv1pfwb5SOFjz+r710YEWzU6LrhuSjpSO+6PeE4A==",
+          "dev": true
+        },
+        "@ethersproject/properties": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.4.1.tgz",
+          "integrity": "sha512-cyCGlF8wWlIZyizsj2PpbJ9I7rIlUAfnHYwy/T90pdkSn/NFTa5YWZx2wTJBe9V7dD65dcrrEMisCRUJiq6n3w==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.4.0"
+          }
+        }
       }
     },
     "@ethersproject/bignumber": {
@@ -432,21 +564,234 @@
       }
     },
     "@ethersproject/contracts": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.3.0.tgz",
-      "integrity": "sha512-eDyQ8ltykvyQqnGZxb/c1e0OnEtzqXhNNC4BX8nhYBCaoBrYYuK/1fLmyEvc5+XUMoxNhwpYkoSSwvPLci7/Zg==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.4.1.tgz",
+      "integrity": "sha512-m+z2ZgPy4pyR15Je//dUaymRUZq5MtDajF6GwFbGAVmKz/RF+DNIPwF0k5qEcL3wPGVqUjFg2/krlCRVTU4T5w==",
       "dev": true,
       "requires": {
-        "@ethersproject/abi": "^5.3.0",
-        "@ethersproject/abstract-provider": "^5.3.0",
-        "@ethersproject/abstract-signer": "^5.3.0",
-        "@ethersproject/address": "^5.3.0",
-        "@ethersproject/bignumber": "^5.3.0",
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/constants": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0",
-        "@ethersproject/properties": "^5.3.0",
-        "@ethersproject/transactions": "^5.3.0"
+        "@ethersproject/abi": "^5.4.0",
+        "@ethersproject/abstract-provider": "^5.4.0",
+        "@ethersproject/abstract-signer": "^5.4.0",
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/constants": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/transactions": "^5.4.0"
+      },
+      "dependencies": {
+        "@ethersproject/abi": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.4.1.tgz",
+          "integrity": "sha512-9mhbjUk76BiSluiiW4BaYyI58KSbDMMQpCLdsAR+RsT2GyATiNYxVv+pGWRrekmsIdY3I+hOqsYQSTkc8L/mcg==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/address": "^5.4.0",
+            "@ethersproject/bignumber": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/constants": "^5.4.0",
+            "@ethersproject/hash": "^5.4.0",
+            "@ethersproject/keccak256": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0",
+            "@ethersproject/strings": "^5.4.0"
+          }
+        },
+        "@ethersproject/abstract-provider": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.4.1.tgz",
+          "integrity": "sha512-3EedfKI3LVpjSKgAxoUaI+gB27frKsxzm+r21w9G60Ugk+3wVLQwhi1LsEJAKNV7WoZc8CIpNrATlL1QFABjtQ==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/networks": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0",
+            "@ethersproject/transactions": "^5.4.0",
+            "@ethersproject/web": "^5.4.0"
+          }
+        },
+        "@ethersproject/abstract-signer": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.4.1.tgz",
+          "integrity": "sha512-SkkFL5HVq1k4/25dM+NWP9MILgohJCgGv5xT5AcRruGz4ILpfHeBtO/y6j+Z3UN/PAjDeb4P7E51Yh8wcGNLGA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/abstract-provider": "^5.4.0",
+            "@ethersproject/bignumber": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0"
+          }
+        },
+        "@ethersproject/address": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.4.0.tgz",
+          "integrity": "sha512-SD0VgOEkcACEG/C6xavlU1Hy3m5DGSXW3CUHkaaEHbAPPsgi0coP5oNPsxau8eTlZOk/bpa/hKeCNoK5IzVI2Q==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/keccak256": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/rlp": "^5.4.0"
+          }
+        },
+        "@ethersproject/base64": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.4.0.tgz",
+          "integrity": "sha512-CjQw6E17QDSSC5jiM9YpF7N1aSCHmYGMt9bWD8PWv6YPMxjsys2/Q8xLrROKI3IWJ7sFfZ8B3flKDTM5wlWuZQ==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0"
+          }
+        },
+        "@ethersproject/bignumber": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.1.tgz",
+          "integrity": "sha512-fJhdxqoQNuDOk6epfM7yD6J8Pol4NUCy1vkaGAkuujZm0+lNow//MKu1hLhRiYV4BsOHyBv5/lsTjF+7hWwhJg==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "bn.js": "^4.11.9"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.4.0.tgz",
+          "integrity": "sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.4.0.tgz",
+          "integrity": "sha512-tzjn6S7sj9+DIIeKTJLjK9WGN2Tj0P++Z8ONEIlZjyoTkBuODN+0VfhAyYksKi43l1Sx9tX2VlFfzjfmr5Wl3Q==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.4.0"
+          }
+        },
+        "@ethersproject/hash": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.4.0.tgz",
+          "integrity": "sha512-xymAM9tmikKgbktOCjW60Z5sdouiIIurkZUr9oW5NOex5uwxrbsYG09kb5bMcNjlVeJD3yPivTNzViIs1GCbqA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/abstract-signer": "^5.4.0",
+            "@ethersproject/address": "^5.4.0",
+            "@ethersproject/bignumber": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/keccak256": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0",
+            "@ethersproject/strings": "^5.4.0"
+          }
+        },
+        "@ethersproject/keccak256": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.4.0.tgz",
+          "integrity": "sha512-FBI1plWet+dPUvAzPAeHzRKiPpETQzqSUWR1wXJGHVWi4i8bOSrpC3NwpkPjgeXG7MnugVc1B42VbfnQikyC/A==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "js-sha3": "0.5.7"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.1.tgz",
+          "integrity": "sha512-DZ+bRinnYLPw1yAC64oRl0QyVZj43QeHIhVKfD/+YwSz4wsv1pfwb5SOFjz+r710YEWzU6LrhuSjpSO+6PeE4A==",
+          "dev": true
+        },
+        "@ethersproject/networks": {
+          "version": "5.4.2",
+          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.4.2.tgz",
+          "integrity": "sha512-eekOhvJyBnuibfJnhtK46b8HimBc5+4gqpvd1/H9LEl7Q7/qhsIhM81dI9Fcnjpk3jB1aTy6bj0hz3cifhNeYw==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/properties": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.4.1.tgz",
+          "integrity": "sha512-cyCGlF8wWlIZyizsj2PpbJ9I7rIlUAfnHYwy/T90pdkSn/NFTa5YWZx2wTJBe9V7dD65dcrrEMisCRUJiq6n3w==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/rlp": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.4.0.tgz",
+          "integrity": "sha512-0I7MZKfi+T5+G8atId9QaQKHRvvasM/kqLyAH4XxBCBchAooH2EX5rL9kYZWwcm3awYV+XC7VF6nLhfeQFKVPg==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/signing-key": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.4.0.tgz",
+          "integrity": "sha512-q8POUeywx6AKg2/jX9qBYZIAmKSB4ubGXdQ88l40hmATj29JnG5pp331nAWwwxPn2Qao4JpWHNZsQN+bPiSW9A==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0",
+            "bn.js": "^4.11.9",
+            "elliptic": "6.5.4",
+            "hash.js": "1.1.7"
+          }
+        },
+        "@ethersproject/strings": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.4.0.tgz",
+          "integrity": "sha512-k/9DkH5UGDhv7aReXLluFG5ExurwtIpUfnDNhQA29w896Dw3i4uDTz01Quaptbks1Uj9kI8wo9tmW73wcIEaWA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/constants": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/transactions": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.4.0.tgz",
+          "integrity": "sha512-s3EjZZt7xa4BkLknJZ98QGoIza94rVjaEed0rzZ/jB9WrIuu/1+tjvYCWzVrystXtDswy7TPBeIepyXwSYa4WQ==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/address": "^5.4.0",
+            "@ethersproject/bignumber": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/constants": "^5.4.0",
+            "@ethersproject/keccak256": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0",
+            "@ethersproject/rlp": "^5.4.0",
+            "@ethersproject/signing-key": "^5.4.0"
+          }
+        },
+        "@ethersproject/web": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.4.0.tgz",
+          "integrity": "sha512-1bUusGmcoRLYgMn6c1BLk1tOKUIFuTg8j+6N8lYlbMpDesnle+i3pGSagGNvwjaiLo4Y5gBibwctpPRmjrh4Og==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/base64": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0",
+            "@ethersproject/strings": "^5.4.0"
+          }
+        }
       }
     },
     "@ethersproject/hash": {
@@ -466,44 +811,404 @@
       }
     },
     "@ethersproject/hdnode": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.3.0.tgz",
-      "integrity": "sha512-zLmmtLNoDMGoYRdjOab01Zqkvp+TmZyCGDAMQF1Bs3yZyBs/kzTNi1qJjR1jVUcPP5CWGtjFwY8iNG8oNV9J8g==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.4.0.tgz",
+      "integrity": "sha512-pKxdS0KAaeVGfZPp1KOiDLB0jba11tG6OP1u11QnYfb7pXn6IZx0xceqWRr6ygke8+Kw74IpOoSi7/DwANhy8Q==",
       "dev": true,
       "requires": {
-        "@ethersproject/abstract-signer": "^5.3.0",
-        "@ethersproject/basex": "^5.3.0",
-        "@ethersproject/bignumber": "^5.3.0",
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0",
-        "@ethersproject/pbkdf2": "^5.3.0",
-        "@ethersproject/properties": "^5.3.0",
-        "@ethersproject/sha2": "^5.3.0",
-        "@ethersproject/signing-key": "^5.3.0",
-        "@ethersproject/strings": "^5.3.0",
-        "@ethersproject/transactions": "^5.3.0",
-        "@ethersproject/wordlists": "^5.3.0"
+        "@ethersproject/abstract-signer": "^5.4.0",
+        "@ethersproject/basex": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/pbkdf2": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/sha2": "^5.4.0",
+        "@ethersproject/signing-key": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0",
+        "@ethersproject/transactions": "^5.4.0",
+        "@ethersproject/wordlists": "^5.4.0"
+      },
+      "dependencies": {
+        "@ethersproject/abstract-provider": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.4.1.tgz",
+          "integrity": "sha512-3EedfKI3LVpjSKgAxoUaI+gB27frKsxzm+r21w9G60Ugk+3wVLQwhi1LsEJAKNV7WoZc8CIpNrATlL1QFABjtQ==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/networks": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0",
+            "@ethersproject/transactions": "^5.4.0",
+            "@ethersproject/web": "^5.4.0"
+          }
+        },
+        "@ethersproject/abstract-signer": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.4.1.tgz",
+          "integrity": "sha512-SkkFL5HVq1k4/25dM+NWP9MILgohJCgGv5xT5AcRruGz4ILpfHeBtO/y6j+Z3UN/PAjDeb4P7E51Yh8wcGNLGA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/abstract-provider": "^5.4.0",
+            "@ethersproject/bignumber": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0"
+          }
+        },
+        "@ethersproject/address": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.4.0.tgz",
+          "integrity": "sha512-SD0VgOEkcACEG/C6xavlU1Hy3m5DGSXW3CUHkaaEHbAPPsgi0coP5oNPsxau8eTlZOk/bpa/hKeCNoK5IzVI2Q==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/keccak256": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/rlp": "^5.4.0"
+          }
+        },
+        "@ethersproject/base64": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.4.0.tgz",
+          "integrity": "sha512-CjQw6E17QDSSC5jiM9YpF7N1aSCHmYGMt9bWD8PWv6YPMxjsys2/Q8xLrROKI3IWJ7sFfZ8B3flKDTM5wlWuZQ==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0"
+          }
+        },
+        "@ethersproject/bignumber": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.1.tgz",
+          "integrity": "sha512-fJhdxqoQNuDOk6epfM7yD6J8Pol4NUCy1vkaGAkuujZm0+lNow//MKu1hLhRiYV4BsOHyBv5/lsTjF+7hWwhJg==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "bn.js": "^4.11.9"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.4.0.tgz",
+          "integrity": "sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.4.0.tgz",
+          "integrity": "sha512-tzjn6S7sj9+DIIeKTJLjK9WGN2Tj0P++Z8ONEIlZjyoTkBuODN+0VfhAyYksKi43l1Sx9tX2VlFfzjfmr5Wl3Q==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.4.0"
+          }
+        },
+        "@ethersproject/keccak256": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.4.0.tgz",
+          "integrity": "sha512-FBI1plWet+dPUvAzPAeHzRKiPpETQzqSUWR1wXJGHVWi4i8bOSrpC3NwpkPjgeXG7MnugVc1B42VbfnQikyC/A==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "js-sha3": "0.5.7"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.1.tgz",
+          "integrity": "sha512-DZ+bRinnYLPw1yAC64oRl0QyVZj43QeHIhVKfD/+YwSz4wsv1pfwb5SOFjz+r710YEWzU6LrhuSjpSO+6PeE4A==",
+          "dev": true
+        },
+        "@ethersproject/networks": {
+          "version": "5.4.2",
+          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.4.2.tgz",
+          "integrity": "sha512-eekOhvJyBnuibfJnhtK46b8HimBc5+4gqpvd1/H9LEl7Q7/qhsIhM81dI9Fcnjpk3jB1aTy6bj0hz3cifhNeYw==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/properties": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.4.1.tgz",
+          "integrity": "sha512-cyCGlF8wWlIZyizsj2PpbJ9I7rIlUAfnHYwy/T90pdkSn/NFTa5YWZx2wTJBe9V7dD65dcrrEMisCRUJiq6n3w==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/rlp": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.4.0.tgz",
+          "integrity": "sha512-0I7MZKfi+T5+G8atId9QaQKHRvvasM/kqLyAH4XxBCBchAooH2EX5rL9kYZWwcm3awYV+XC7VF6nLhfeQFKVPg==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/signing-key": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.4.0.tgz",
+          "integrity": "sha512-q8POUeywx6AKg2/jX9qBYZIAmKSB4ubGXdQ88l40hmATj29JnG5pp331nAWwwxPn2Qao4JpWHNZsQN+bPiSW9A==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0",
+            "bn.js": "^4.11.9",
+            "elliptic": "6.5.4",
+            "hash.js": "1.1.7"
+          }
+        },
+        "@ethersproject/strings": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.4.0.tgz",
+          "integrity": "sha512-k/9DkH5UGDhv7aReXLluFG5ExurwtIpUfnDNhQA29w896Dw3i4uDTz01Quaptbks1Uj9kI8wo9tmW73wcIEaWA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/constants": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/transactions": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.4.0.tgz",
+          "integrity": "sha512-s3EjZZt7xa4BkLknJZ98QGoIza94rVjaEed0rzZ/jB9WrIuu/1+tjvYCWzVrystXtDswy7TPBeIepyXwSYa4WQ==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/address": "^5.4.0",
+            "@ethersproject/bignumber": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/constants": "^5.4.0",
+            "@ethersproject/keccak256": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0",
+            "@ethersproject/rlp": "^5.4.0",
+            "@ethersproject/signing-key": "^5.4.0"
+          }
+        },
+        "@ethersproject/web": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.4.0.tgz",
+          "integrity": "sha512-1bUusGmcoRLYgMn6c1BLk1tOKUIFuTg8j+6N8lYlbMpDesnle+i3pGSagGNvwjaiLo4Y5gBibwctpPRmjrh4Og==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/base64": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0",
+            "@ethersproject/strings": "^5.4.0"
+          }
+        }
       }
     },
     "@ethersproject/json-wallets": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.3.0.tgz",
-      "integrity": "sha512-/xwbqaIb5grUIGNmeEaz8GdcpmDr++X8WT4Jqcclnxow8PXCUHFeDxjf3O+nSuoqOYG/Ds0+BI5xuQKbva6Xkw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.4.0.tgz",
+      "integrity": "sha512-igWcu3fx4aiczrzEHwG1xJZo9l1cFfQOWzTqwRw/xcvxTk58q4f9M7cjh51EKphMHvrJtcezJ1gf1q1AUOfEQQ==",
       "dev": true,
       "requires": {
-        "@ethersproject/abstract-signer": "^5.3.0",
-        "@ethersproject/address": "^5.3.0",
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/hdnode": "^5.3.0",
-        "@ethersproject/keccak256": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0",
-        "@ethersproject/pbkdf2": "^5.3.0",
-        "@ethersproject/properties": "^5.3.0",
-        "@ethersproject/random": "^5.3.0",
-        "@ethersproject/strings": "^5.3.0",
-        "@ethersproject/transactions": "^5.3.0",
+        "@ethersproject/abstract-signer": "^5.4.0",
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/hdnode": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/pbkdf2": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/random": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0",
+        "@ethersproject/transactions": "^5.4.0",
         "aes-js": "3.0.0",
         "scrypt-js": "3.0.1"
+      },
+      "dependencies": {
+        "@ethersproject/abstract-provider": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.4.1.tgz",
+          "integrity": "sha512-3EedfKI3LVpjSKgAxoUaI+gB27frKsxzm+r21w9G60Ugk+3wVLQwhi1LsEJAKNV7WoZc8CIpNrATlL1QFABjtQ==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/networks": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0",
+            "@ethersproject/transactions": "^5.4.0",
+            "@ethersproject/web": "^5.4.0"
+          }
+        },
+        "@ethersproject/abstract-signer": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.4.1.tgz",
+          "integrity": "sha512-SkkFL5HVq1k4/25dM+NWP9MILgohJCgGv5xT5AcRruGz4ILpfHeBtO/y6j+Z3UN/PAjDeb4P7E51Yh8wcGNLGA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/abstract-provider": "^5.4.0",
+            "@ethersproject/bignumber": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0"
+          }
+        },
+        "@ethersproject/address": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.4.0.tgz",
+          "integrity": "sha512-SD0VgOEkcACEG/C6xavlU1Hy3m5DGSXW3CUHkaaEHbAPPsgi0coP5oNPsxau8eTlZOk/bpa/hKeCNoK5IzVI2Q==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/keccak256": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/rlp": "^5.4.0"
+          }
+        },
+        "@ethersproject/base64": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.4.0.tgz",
+          "integrity": "sha512-CjQw6E17QDSSC5jiM9YpF7N1aSCHmYGMt9bWD8PWv6YPMxjsys2/Q8xLrROKI3IWJ7sFfZ8B3flKDTM5wlWuZQ==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0"
+          }
+        },
+        "@ethersproject/bignumber": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.1.tgz",
+          "integrity": "sha512-fJhdxqoQNuDOk6epfM7yD6J8Pol4NUCy1vkaGAkuujZm0+lNow//MKu1hLhRiYV4BsOHyBv5/lsTjF+7hWwhJg==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "bn.js": "^4.11.9"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.4.0.tgz",
+          "integrity": "sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.4.0.tgz",
+          "integrity": "sha512-tzjn6S7sj9+DIIeKTJLjK9WGN2Tj0P++Z8ONEIlZjyoTkBuODN+0VfhAyYksKi43l1Sx9tX2VlFfzjfmr5Wl3Q==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.4.0"
+          }
+        },
+        "@ethersproject/keccak256": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.4.0.tgz",
+          "integrity": "sha512-FBI1plWet+dPUvAzPAeHzRKiPpETQzqSUWR1wXJGHVWi4i8bOSrpC3NwpkPjgeXG7MnugVc1B42VbfnQikyC/A==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "js-sha3": "0.5.7"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.1.tgz",
+          "integrity": "sha512-DZ+bRinnYLPw1yAC64oRl0QyVZj43QeHIhVKfD/+YwSz4wsv1pfwb5SOFjz+r710YEWzU6LrhuSjpSO+6PeE4A==",
+          "dev": true
+        },
+        "@ethersproject/networks": {
+          "version": "5.4.2",
+          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.4.2.tgz",
+          "integrity": "sha512-eekOhvJyBnuibfJnhtK46b8HimBc5+4gqpvd1/H9LEl7Q7/qhsIhM81dI9Fcnjpk3jB1aTy6bj0hz3cifhNeYw==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/properties": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.4.1.tgz",
+          "integrity": "sha512-cyCGlF8wWlIZyizsj2PpbJ9I7rIlUAfnHYwy/T90pdkSn/NFTa5YWZx2wTJBe9V7dD65dcrrEMisCRUJiq6n3w==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/rlp": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.4.0.tgz",
+          "integrity": "sha512-0I7MZKfi+T5+G8atId9QaQKHRvvasM/kqLyAH4XxBCBchAooH2EX5rL9kYZWwcm3awYV+XC7VF6nLhfeQFKVPg==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/signing-key": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.4.0.tgz",
+          "integrity": "sha512-q8POUeywx6AKg2/jX9qBYZIAmKSB4ubGXdQ88l40hmATj29JnG5pp331nAWwwxPn2Qao4JpWHNZsQN+bPiSW9A==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0",
+            "bn.js": "^4.11.9",
+            "elliptic": "6.5.4",
+            "hash.js": "1.1.7"
+          }
+        },
+        "@ethersproject/strings": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.4.0.tgz",
+          "integrity": "sha512-k/9DkH5UGDhv7aReXLluFG5ExurwtIpUfnDNhQA29w896Dw3i4uDTz01Quaptbks1Uj9kI8wo9tmW73wcIEaWA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/constants": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/transactions": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.4.0.tgz",
+          "integrity": "sha512-s3EjZZt7xa4BkLknJZ98QGoIza94rVjaEed0rzZ/jB9WrIuu/1+tjvYCWzVrystXtDswy7TPBeIepyXwSYa4WQ==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/address": "^5.4.0",
+            "@ethersproject/bignumber": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/constants": "^5.4.0",
+            "@ethersproject/keccak256": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0",
+            "@ethersproject/rlp": "^5.4.0",
+            "@ethersproject/signing-key": "^5.4.0"
+          }
+        },
+        "@ethersproject/web": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.4.0.tgz",
+          "integrity": "sha512-1bUusGmcoRLYgMn6c1BLk1tOKUIFuTg8j+6N8lYlbMpDesnle+i3pGSagGNvwjaiLo4Y5gBibwctpPRmjrh4Og==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/base64": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0",
+            "@ethersproject/strings": "^5.4.0"
+          }
+        }
       }
     },
     "@ethersproject/keccak256": {
@@ -532,13 +1237,30 @@
       }
     },
     "@ethersproject/pbkdf2": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.3.0.tgz",
-      "integrity": "sha512-Q9ChVU6gBFiex0FSdtzo4b0SAKz3ZYcYVFLrEWHL0FnHvNk3J3WgAtRNtBQGQYn/T5wkoTdZttMbfBkFlaiWcA==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.4.0.tgz",
+      "integrity": "sha512-x94aIv6tiA04g6BnazZSLoRXqyusawRyZWlUhKip2jvoLpzJuLb//KtMM6PEovE47pMbW+Qe1uw+68ameJjB7g==",
       "dev": true,
       "requires": {
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/sha2": "^5.3.0"
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/sha2": "^5.4.0"
+      },
+      "dependencies": {
+        "@ethersproject/bytes": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.4.0.tgz",
+          "integrity": "sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.1.tgz",
+          "integrity": "sha512-DZ+bRinnYLPw1yAC64oRl0QyVZj43QeHIhVKfD/+YwSz4wsv1pfwb5SOFjz+r710YEWzU6LrhuSjpSO+6PeE4A==",
+          "dev": true
+        }
       }
     },
     "@ethersproject/properties": {
@@ -551,40 +1273,253 @@
       }
     },
     "@ethersproject/providers": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.3.1.tgz",
-      "integrity": "sha512-HC63vENTrur6/JKEhcQbA8PRDj1FAesdpX98IW+xAAo3EAkf70ou5fMIA3KCGzJDLNTeYA4C2Bonz849tVLekg==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.4.5.tgz",
+      "integrity": "sha512-1GkrvkiAw3Fj28cwi1Sqm8ED1RtERtpdXmRfwIBGmqBSN5MoeRUHuwHPppMtbPayPgpFcvD7/Gdc9doO5fGYgw==",
       "dev": true,
       "requires": {
-        "@ethersproject/abstract-provider": "^5.3.0",
-        "@ethersproject/abstract-signer": "^5.3.0",
-        "@ethersproject/address": "^5.3.0",
-        "@ethersproject/basex": "^5.3.0",
-        "@ethersproject/bignumber": "^5.3.0",
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/constants": "^5.3.0",
-        "@ethersproject/hash": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0",
-        "@ethersproject/networks": "^5.3.0",
-        "@ethersproject/properties": "^5.3.0",
-        "@ethersproject/random": "^5.3.0",
-        "@ethersproject/rlp": "^5.3.0",
-        "@ethersproject/sha2": "^5.3.0",
-        "@ethersproject/strings": "^5.3.0",
-        "@ethersproject/transactions": "^5.3.0",
-        "@ethersproject/web": "^5.3.0",
+        "@ethersproject/abstract-provider": "^5.4.0",
+        "@ethersproject/abstract-signer": "^5.4.0",
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/basex": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/constants": "^5.4.0",
+        "@ethersproject/hash": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/networks": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/random": "^5.4.0",
+        "@ethersproject/rlp": "^5.4.0",
+        "@ethersproject/sha2": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0",
+        "@ethersproject/transactions": "^5.4.0",
+        "@ethersproject/web": "^5.4.0",
         "bech32": "1.1.4",
         "ws": "7.4.6"
+      },
+      "dependencies": {
+        "@ethersproject/abstract-provider": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.4.1.tgz",
+          "integrity": "sha512-3EedfKI3LVpjSKgAxoUaI+gB27frKsxzm+r21w9G60Ugk+3wVLQwhi1LsEJAKNV7WoZc8CIpNrATlL1QFABjtQ==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/networks": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0",
+            "@ethersproject/transactions": "^5.4.0",
+            "@ethersproject/web": "^5.4.0"
+          }
+        },
+        "@ethersproject/abstract-signer": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.4.1.tgz",
+          "integrity": "sha512-SkkFL5HVq1k4/25dM+NWP9MILgohJCgGv5xT5AcRruGz4ILpfHeBtO/y6j+Z3UN/PAjDeb4P7E51Yh8wcGNLGA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/abstract-provider": "^5.4.0",
+            "@ethersproject/bignumber": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0"
+          }
+        },
+        "@ethersproject/address": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.4.0.tgz",
+          "integrity": "sha512-SD0VgOEkcACEG/C6xavlU1Hy3m5DGSXW3CUHkaaEHbAPPsgi0coP5oNPsxau8eTlZOk/bpa/hKeCNoK5IzVI2Q==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/keccak256": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/rlp": "^5.4.0"
+          }
+        },
+        "@ethersproject/base64": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.4.0.tgz",
+          "integrity": "sha512-CjQw6E17QDSSC5jiM9YpF7N1aSCHmYGMt9bWD8PWv6YPMxjsys2/Q8xLrROKI3IWJ7sFfZ8B3flKDTM5wlWuZQ==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0"
+          }
+        },
+        "@ethersproject/bignumber": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.1.tgz",
+          "integrity": "sha512-fJhdxqoQNuDOk6epfM7yD6J8Pol4NUCy1vkaGAkuujZm0+lNow//MKu1hLhRiYV4BsOHyBv5/lsTjF+7hWwhJg==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "bn.js": "^4.11.9"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.4.0.tgz",
+          "integrity": "sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.4.0.tgz",
+          "integrity": "sha512-tzjn6S7sj9+DIIeKTJLjK9WGN2Tj0P++Z8ONEIlZjyoTkBuODN+0VfhAyYksKi43l1Sx9tX2VlFfzjfmr5Wl3Q==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.4.0"
+          }
+        },
+        "@ethersproject/hash": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.4.0.tgz",
+          "integrity": "sha512-xymAM9tmikKgbktOCjW60Z5sdouiIIurkZUr9oW5NOex5uwxrbsYG09kb5bMcNjlVeJD3yPivTNzViIs1GCbqA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/abstract-signer": "^5.4.0",
+            "@ethersproject/address": "^5.4.0",
+            "@ethersproject/bignumber": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/keccak256": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0",
+            "@ethersproject/strings": "^5.4.0"
+          }
+        },
+        "@ethersproject/keccak256": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.4.0.tgz",
+          "integrity": "sha512-FBI1plWet+dPUvAzPAeHzRKiPpETQzqSUWR1wXJGHVWi4i8bOSrpC3NwpkPjgeXG7MnugVc1B42VbfnQikyC/A==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "js-sha3": "0.5.7"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.1.tgz",
+          "integrity": "sha512-DZ+bRinnYLPw1yAC64oRl0QyVZj43QeHIhVKfD/+YwSz4wsv1pfwb5SOFjz+r710YEWzU6LrhuSjpSO+6PeE4A==",
+          "dev": true
+        },
+        "@ethersproject/networks": {
+          "version": "5.4.2",
+          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.4.2.tgz",
+          "integrity": "sha512-eekOhvJyBnuibfJnhtK46b8HimBc5+4gqpvd1/H9LEl7Q7/qhsIhM81dI9Fcnjpk3jB1aTy6bj0hz3cifhNeYw==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/properties": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.4.1.tgz",
+          "integrity": "sha512-cyCGlF8wWlIZyizsj2PpbJ9I7rIlUAfnHYwy/T90pdkSn/NFTa5YWZx2wTJBe9V7dD65dcrrEMisCRUJiq6n3w==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/rlp": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.4.0.tgz",
+          "integrity": "sha512-0I7MZKfi+T5+G8atId9QaQKHRvvasM/kqLyAH4XxBCBchAooH2EX5rL9kYZWwcm3awYV+XC7VF6nLhfeQFKVPg==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/signing-key": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.4.0.tgz",
+          "integrity": "sha512-q8POUeywx6AKg2/jX9qBYZIAmKSB4ubGXdQ88l40hmATj29JnG5pp331nAWwwxPn2Qao4JpWHNZsQN+bPiSW9A==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0",
+            "bn.js": "^4.11.9",
+            "elliptic": "6.5.4",
+            "hash.js": "1.1.7"
+          }
+        },
+        "@ethersproject/strings": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.4.0.tgz",
+          "integrity": "sha512-k/9DkH5UGDhv7aReXLluFG5ExurwtIpUfnDNhQA29w896Dw3i4uDTz01Quaptbks1Uj9kI8wo9tmW73wcIEaWA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/constants": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/transactions": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.4.0.tgz",
+          "integrity": "sha512-s3EjZZt7xa4BkLknJZ98QGoIza94rVjaEed0rzZ/jB9WrIuu/1+tjvYCWzVrystXtDswy7TPBeIepyXwSYa4WQ==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/address": "^5.4.0",
+            "@ethersproject/bignumber": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/constants": "^5.4.0",
+            "@ethersproject/keccak256": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0",
+            "@ethersproject/rlp": "^5.4.0",
+            "@ethersproject/signing-key": "^5.4.0"
+          }
+        },
+        "@ethersproject/web": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.4.0.tgz",
+          "integrity": "sha512-1bUusGmcoRLYgMn6c1BLk1tOKUIFuTg8j+6N8lYlbMpDesnle+i3pGSagGNvwjaiLo4Y5gBibwctpPRmjrh4Og==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/base64": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0",
+            "@ethersproject/strings": "^5.4.0"
+          }
+        }
       }
     },
     "@ethersproject/random": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.3.0.tgz",
-      "integrity": "sha512-A5SL/4inutSwt3Fh2OD0x2gz+x6GHmuUnIPkR7zAiTidMD2N8F6tZdMF1hlQKWVCcVMWhEQg8mWijhEzm6BBYw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.4.0.tgz",
+      "integrity": "sha512-pnpWNQlf0VAZDEOVp1rsYQosmv2o0ITS/PecNw+mS2/btF8eYdspkN0vIXrCMtkX09EAh9bdk8GoXmFXM1eAKw==",
       "dev": true,
       "requires": {
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0"
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0"
+      },
+      "dependencies": {
+        "@ethersproject/bytes": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.4.0.tgz",
+          "integrity": "sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.1.tgz",
+          "integrity": "sha512-DZ+bRinnYLPw1yAC64oRl0QyVZj43QeHIhVKfD/+YwSz4wsv1pfwb5SOFjz+r710YEWzU6LrhuSjpSO+6PeE4A==",
+          "dev": true
+        }
       }
     },
     "@ethersproject/rlp": {
@@ -598,14 +1533,31 @@
       }
     },
     "@ethersproject/sha2": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.3.0.tgz",
-      "integrity": "sha512-r5ftlwKcocYEuFz2JbeKOT5SAsCV4m1RJDsTOEfQ5L67ZC7NFDK5i7maPdn1bx4nPhylF9VAwxSrQ1esmwzylg==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.4.0.tgz",
+      "integrity": "sha512-siheo36r1WD7Cy+bDdE1BJ8y0bDtqXCOxRMzPa4bV1TGt/eTUUt03BHoJNB6reWJD8A30E/pdJ8WFkq+/uz4Gg==",
       "dev": true,
       "requires": {
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
         "hash.js": "1.1.7"
+      },
+      "dependencies": {
+        "@ethersproject/bytes": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.4.0.tgz",
+          "integrity": "sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.1.tgz",
+          "integrity": "sha512-DZ+bRinnYLPw1yAC64oRl0QyVZj43QeHIhVKfD/+YwSz4wsv1pfwb5SOFjz+r710YEWzU6LrhuSjpSO+6PeE4A==",
+          "dev": true
+        }
       }
     },
     "@ethersproject/signing-key": {
@@ -623,16 +1575,74 @@
       }
     },
     "@ethersproject/solidity": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.3.0.tgz",
-      "integrity": "sha512-uLRBaNUiISHbut94XKewJgQh6UmydWTBp71I7I21pkjVXfZO2dJ5EOo3jCnumJc01M4LOm79dlNNmF3oGIvweQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.4.0.tgz",
+      "integrity": "sha512-XFQTZ7wFSHOhHcV1DpcWj7VXECEiSrBuv7JErJvB9Uo+KfCdc3QtUZV+Vjh/AAaYgezUEKbCtE6Khjm44seevQ==",
       "dev": true,
       "requires": {
-        "@ethersproject/bignumber": "^5.3.0",
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/keccak256": "^5.3.0",
-        "@ethersproject/sha2": "^5.3.0",
-        "@ethersproject/strings": "^5.3.0"
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/sha2": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0"
+      },
+      "dependencies": {
+        "@ethersproject/bignumber": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.1.tgz",
+          "integrity": "sha512-fJhdxqoQNuDOk6epfM7yD6J8Pol4NUCy1vkaGAkuujZm0+lNow//MKu1hLhRiYV4BsOHyBv5/lsTjF+7hWwhJg==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "bn.js": "^4.11.9"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.4.0.tgz",
+          "integrity": "sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.4.0.tgz",
+          "integrity": "sha512-tzjn6S7sj9+DIIeKTJLjK9WGN2Tj0P++Z8ONEIlZjyoTkBuODN+0VfhAyYksKi43l1Sx9tX2VlFfzjfmr5Wl3Q==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.4.0"
+          }
+        },
+        "@ethersproject/keccak256": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.4.0.tgz",
+          "integrity": "sha512-FBI1plWet+dPUvAzPAeHzRKiPpETQzqSUWR1wXJGHVWi4i8bOSrpC3NwpkPjgeXG7MnugVc1B42VbfnQikyC/A==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "js-sha3": "0.5.7"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.1.tgz",
+          "integrity": "sha512-DZ+bRinnYLPw1yAC64oRl0QyVZj43QeHIhVKfD/+YwSz4wsv1pfwb5SOFjz+r710YEWzU6LrhuSjpSO+6PeE4A==",
+          "dev": true
+        },
+        "@ethersproject/strings": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.4.0.tgz",
+          "integrity": "sha512-k/9DkH5UGDhv7aReXLluFG5ExurwtIpUfnDNhQA29w896Dw3i4uDTz01Quaptbks1Uj9kI8wo9tmW73wcIEaWA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/constants": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0"
+          }
+        }
       }
     },
     "@ethersproject/strings": {
@@ -664,37 +1674,270 @@
       }
     },
     "@ethersproject/units": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.3.0.tgz",
-      "integrity": "sha512-BkfccZGwfJ6Ob+AelpIrgAzuNhrN2VLp3AILnkqTOv+yBdsc83V4AYf25XC/u0rHnWl6f4POaietPwlMqP2vUg==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.4.0.tgz",
+      "integrity": "sha512-Z88krX40KCp+JqPCP5oPv5p750g+uU6gopDYRTBGcDvOASh6qhiEYCRatuM/suC4S2XW9Zz90QI35MfSrTIaFg==",
       "dev": true,
       "requires": {
-        "@ethersproject/bignumber": "^5.3.0",
-        "@ethersproject/constants": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0"
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/constants": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0"
+      },
+      "dependencies": {
+        "@ethersproject/bignumber": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.1.tgz",
+          "integrity": "sha512-fJhdxqoQNuDOk6epfM7yD6J8Pol4NUCy1vkaGAkuujZm0+lNow//MKu1hLhRiYV4BsOHyBv5/lsTjF+7hWwhJg==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "bn.js": "^4.11.9"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.4.0.tgz",
+          "integrity": "sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.4.0.tgz",
+          "integrity": "sha512-tzjn6S7sj9+DIIeKTJLjK9WGN2Tj0P++Z8ONEIlZjyoTkBuODN+0VfhAyYksKi43l1Sx9tX2VlFfzjfmr5Wl3Q==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.4.0"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.1.tgz",
+          "integrity": "sha512-DZ+bRinnYLPw1yAC64oRl0QyVZj43QeHIhVKfD/+YwSz4wsv1pfwb5SOFjz+r710YEWzU6LrhuSjpSO+6PeE4A==",
+          "dev": true
+        }
       }
     },
     "@ethersproject/wallet": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.3.0.tgz",
-      "integrity": "sha512-boYBLydG6671p9QoG6EinNnNzbm7DNOjVT20eV8J6HQEq4aUaGiA2CytF2vK+2rOEWbzhZqoNDt6AlkE1LlsTg==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.4.0.tgz",
+      "integrity": "sha512-wU29majLjM6AjCjpat21mPPviG+EpK7wY1+jzKD0fg3ui5fgedf2zEu1RDgpfIMsfn8fJHJuzM4zXZ2+hSHaSQ==",
       "dev": true,
       "requires": {
-        "@ethersproject/abstract-provider": "^5.3.0",
-        "@ethersproject/abstract-signer": "^5.3.0",
-        "@ethersproject/address": "^5.3.0",
-        "@ethersproject/bignumber": "^5.3.0",
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/hash": "^5.3.0",
-        "@ethersproject/hdnode": "^5.3.0",
-        "@ethersproject/json-wallets": "^5.3.0",
-        "@ethersproject/keccak256": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0",
-        "@ethersproject/properties": "^5.3.0",
-        "@ethersproject/random": "^5.3.0",
-        "@ethersproject/signing-key": "^5.3.0",
-        "@ethersproject/transactions": "^5.3.0",
-        "@ethersproject/wordlists": "^5.3.0"
+        "@ethersproject/abstract-provider": "^5.4.0",
+        "@ethersproject/abstract-signer": "^5.4.0",
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/hash": "^5.4.0",
+        "@ethersproject/hdnode": "^5.4.0",
+        "@ethersproject/json-wallets": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/random": "^5.4.0",
+        "@ethersproject/signing-key": "^5.4.0",
+        "@ethersproject/transactions": "^5.4.0",
+        "@ethersproject/wordlists": "^5.4.0"
+      },
+      "dependencies": {
+        "@ethersproject/abstract-provider": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.4.1.tgz",
+          "integrity": "sha512-3EedfKI3LVpjSKgAxoUaI+gB27frKsxzm+r21w9G60Ugk+3wVLQwhi1LsEJAKNV7WoZc8CIpNrATlL1QFABjtQ==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/networks": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0",
+            "@ethersproject/transactions": "^5.4.0",
+            "@ethersproject/web": "^5.4.0"
+          }
+        },
+        "@ethersproject/abstract-signer": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.4.1.tgz",
+          "integrity": "sha512-SkkFL5HVq1k4/25dM+NWP9MILgohJCgGv5xT5AcRruGz4ILpfHeBtO/y6j+Z3UN/PAjDeb4P7E51Yh8wcGNLGA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/abstract-provider": "^5.4.0",
+            "@ethersproject/bignumber": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0"
+          }
+        },
+        "@ethersproject/address": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.4.0.tgz",
+          "integrity": "sha512-SD0VgOEkcACEG/C6xavlU1Hy3m5DGSXW3CUHkaaEHbAPPsgi0coP5oNPsxau8eTlZOk/bpa/hKeCNoK5IzVI2Q==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/keccak256": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/rlp": "^5.4.0"
+          }
+        },
+        "@ethersproject/base64": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.4.0.tgz",
+          "integrity": "sha512-CjQw6E17QDSSC5jiM9YpF7N1aSCHmYGMt9bWD8PWv6YPMxjsys2/Q8xLrROKI3IWJ7sFfZ8B3flKDTM5wlWuZQ==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0"
+          }
+        },
+        "@ethersproject/bignumber": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.1.tgz",
+          "integrity": "sha512-fJhdxqoQNuDOk6epfM7yD6J8Pol4NUCy1vkaGAkuujZm0+lNow//MKu1hLhRiYV4BsOHyBv5/lsTjF+7hWwhJg==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "bn.js": "^4.11.9"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.4.0.tgz",
+          "integrity": "sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.4.0.tgz",
+          "integrity": "sha512-tzjn6S7sj9+DIIeKTJLjK9WGN2Tj0P++Z8ONEIlZjyoTkBuODN+0VfhAyYksKi43l1Sx9tX2VlFfzjfmr5Wl3Q==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.4.0"
+          }
+        },
+        "@ethersproject/hash": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.4.0.tgz",
+          "integrity": "sha512-xymAM9tmikKgbktOCjW60Z5sdouiIIurkZUr9oW5NOex5uwxrbsYG09kb5bMcNjlVeJD3yPivTNzViIs1GCbqA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/abstract-signer": "^5.4.0",
+            "@ethersproject/address": "^5.4.0",
+            "@ethersproject/bignumber": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/keccak256": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0",
+            "@ethersproject/strings": "^5.4.0"
+          }
+        },
+        "@ethersproject/keccak256": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.4.0.tgz",
+          "integrity": "sha512-FBI1plWet+dPUvAzPAeHzRKiPpETQzqSUWR1wXJGHVWi4i8bOSrpC3NwpkPjgeXG7MnugVc1B42VbfnQikyC/A==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "js-sha3": "0.5.7"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.1.tgz",
+          "integrity": "sha512-DZ+bRinnYLPw1yAC64oRl0QyVZj43QeHIhVKfD/+YwSz4wsv1pfwb5SOFjz+r710YEWzU6LrhuSjpSO+6PeE4A==",
+          "dev": true
+        },
+        "@ethersproject/networks": {
+          "version": "5.4.2",
+          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.4.2.tgz",
+          "integrity": "sha512-eekOhvJyBnuibfJnhtK46b8HimBc5+4gqpvd1/H9LEl7Q7/qhsIhM81dI9Fcnjpk3jB1aTy6bj0hz3cifhNeYw==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/properties": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.4.1.tgz",
+          "integrity": "sha512-cyCGlF8wWlIZyizsj2PpbJ9I7rIlUAfnHYwy/T90pdkSn/NFTa5YWZx2wTJBe9V7dD65dcrrEMisCRUJiq6n3w==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/rlp": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.4.0.tgz",
+          "integrity": "sha512-0I7MZKfi+T5+G8atId9QaQKHRvvasM/kqLyAH4XxBCBchAooH2EX5rL9kYZWwcm3awYV+XC7VF6nLhfeQFKVPg==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/signing-key": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.4.0.tgz",
+          "integrity": "sha512-q8POUeywx6AKg2/jX9qBYZIAmKSB4ubGXdQ88l40hmATj29JnG5pp331nAWwwxPn2Qao4JpWHNZsQN+bPiSW9A==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0",
+            "bn.js": "^4.11.9",
+            "elliptic": "6.5.4",
+            "hash.js": "1.1.7"
+          }
+        },
+        "@ethersproject/strings": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.4.0.tgz",
+          "integrity": "sha512-k/9DkH5UGDhv7aReXLluFG5ExurwtIpUfnDNhQA29w896Dw3i4uDTz01Quaptbks1Uj9kI8wo9tmW73wcIEaWA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/constants": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/transactions": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.4.0.tgz",
+          "integrity": "sha512-s3EjZZt7xa4BkLknJZ98QGoIza94rVjaEed0rzZ/jB9WrIuu/1+tjvYCWzVrystXtDswy7TPBeIepyXwSYa4WQ==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/address": "^5.4.0",
+            "@ethersproject/bignumber": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/constants": "^5.4.0",
+            "@ethersproject/keccak256": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0",
+            "@ethersproject/rlp": "^5.4.0",
+            "@ethersproject/signing-key": "^5.4.0"
+          }
+        },
+        "@ethersproject/web": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.4.0.tgz",
+          "integrity": "sha512-1bUusGmcoRLYgMn6c1BLk1tOKUIFuTg8j+6N8lYlbMpDesnle+i3pGSagGNvwjaiLo4Y5gBibwctpPRmjrh4Og==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/base64": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0",
+            "@ethersproject/strings": "^5.4.0"
+          }
+        }
       }
     },
     "@ethersproject/web": {
@@ -711,16 +1954,212 @@
       }
     },
     "@ethersproject/wordlists": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.3.0.tgz",
-      "integrity": "sha512-JcwumCZcsUxgWpiFU/BRy6b4KlTRdOmYvOKZcAw/3sdF93/pZyPW5Od2hFkHS8oWp4xS06YQ+qHqQhdcxdHafQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.4.0.tgz",
+      "integrity": "sha512-FemEkf6a+EBKEPxlzeVgUaVSodU7G0Na89jqKjmWMlDB0tomoU8RlEMgUvXyqtrg8N4cwpLh8nyRnm1Nay1isA==",
       "dev": true,
       "requires": {
-        "@ethersproject/bytes": "^5.3.0",
-        "@ethersproject/hash": "^5.3.0",
-        "@ethersproject/logger": "^5.3.0",
-        "@ethersproject/properties": "^5.3.0",
-        "@ethersproject/strings": "^5.3.0"
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/hash": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0"
+      },
+      "dependencies": {
+        "@ethersproject/abstract-provider": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.4.1.tgz",
+          "integrity": "sha512-3EedfKI3LVpjSKgAxoUaI+gB27frKsxzm+r21w9G60Ugk+3wVLQwhi1LsEJAKNV7WoZc8CIpNrATlL1QFABjtQ==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/networks": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0",
+            "@ethersproject/transactions": "^5.4.0",
+            "@ethersproject/web": "^5.4.0"
+          }
+        },
+        "@ethersproject/abstract-signer": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.4.1.tgz",
+          "integrity": "sha512-SkkFL5HVq1k4/25dM+NWP9MILgohJCgGv5xT5AcRruGz4ILpfHeBtO/y6j+Z3UN/PAjDeb4P7E51Yh8wcGNLGA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/abstract-provider": "^5.4.0",
+            "@ethersproject/bignumber": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0"
+          }
+        },
+        "@ethersproject/address": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.4.0.tgz",
+          "integrity": "sha512-SD0VgOEkcACEG/C6xavlU1Hy3m5DGSXW3CUHkaaEHbAPPsgi0coP5oNPsxau8eTlZOk/bpa/hKeCNoK5IzVI2Q==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/keccak256": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/rlp": "^5.4.0"
+          }
+        },
+        "@ethersproject/base64": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.4.0.tgz",
+          "integrity": "sha512-CjQw6E17QDSSC5jiM9YpF7N1aSCHmYGMt9bWD8PWv6YPMxjsys2/Q8xLrROKI3IWJ7sFfZ8B3flKDTM5wlWuZQ==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0"
+          }
+        },
+        "@ethersproject/bignumber": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.1.tgz",
+          "integrity": "sha512-fJhdxqoQNuDOk6epfM7yD6J8Pol4NUCy1vkaGAkuujZm0+lNow//MKu1hLhRiYV4BsOHyBv5/lsTjF+7hWwhJg==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "bn.js": "^4.11.9"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.4.0.tgz",
+          "integrity": "sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.4.0.tgz",
+          "integrity": "sha512-tzjn6S7sj9+DIIeKTJLjK9WGN2Tj0P++Z8ONEIlZjyoTkBuODN+0VfhAyYksKi43l1Sx9tX2VlFfzjfmr5Wl3Q==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.4.0"
+          }
+        },
+        "@ethersproject/hash": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.4.0.tgz",
+          "integrity": "sha512-xymAM9tmikKgbktOCjW60Z5sdouiIIurkZUr9oW5NOex5uwxrbsYG09kb5bMcNjlVeJD3yPivTNzViIs1GCbqA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/abstract-signer": "^5.4.0",
+            "@ethersproject/address": "^5.4.0",
+            "@ethersproject/bignumber": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/keccak256": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0",
+            "@ethersproject/strings": "^5.4.0"
+          }
+        },
+        "@ethersproject/keccak256": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.4.0.tgz",
+          "integrity": "sha512-FBI1plWet+dPUvAzPAeHzRKiPpETQzqSUWR1wXJGHVWi4i8bOSrpC3NwpkPjgeXG7MnugVc1B42VbfnQikyC/A==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "js-sha3": "0.5.7"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.1.tgz",
+          "integrity": "sha512-DZ+bRinnYLPw1yAC64oRl0QyVZj43QeHIhVKfD/+YwSz4wsv1pfwb5SOFjz+r710YEWzU6LrhuSjpSO+6PeE4A==",
+          "dev": true
+        },
+        "@ethersproject/networks": {
+          "version": "5.4.2",
+          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.4.2.tgz",
+          "integrity": "sha512-eekOhvJyBnuibfJnhtK46b8HimBc5+4gqpvd1/H9LEl7Q7/qhsIhM81dI9Fcnjpk3jB1aTy6bj0hz3cifhNeYw==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/properties": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.4.1.tgz",
+          "integrity": "sha512-cyCGlF8wWlIZyizsj2PpbJ9I7rIlUAfnHYwy/T90pdkSn/NFTa5YWZx2wTJBe9V7dD65dcrrEMisCRUJiq6n3w==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/rlp": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.4.0.tgz",
+          "integrity": "sha512-0I7MZKfi+T5+G8atId9QaQKHRvvasM/kqLyAH4XxBCBchAooH2EX5rL9kYZWwcm3awYV+XC7VF6nLhfeQFKVPg==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/signing-key": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.4.0.tgz",
+          "integrity": "sha512-q8POUeywx6AKg2/jX9qBYZIAmKSB4ubGXdQ88l40hmATj29JnG5pp331nAWwwxPn2Qao4JpWHNZsQN+bPiSW9A==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0",
+            "bn.js": "^4.11.9",
+            "elliptic": "6.5.4",
+            "hash.js": "1.1.7"
+          }
+        },
+        "@ethersproject/strings": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.4.0.tgz",
+          "integrity": "sha512-k/9DkH5UGDhv7aReXLluFG5ExurwtIpUfnDNhQA29w896Dw3i4uDTz01Quaptbks1Uj9kI8wo9tmW73wcIEaWA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/constants": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/transactions": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.4.0.tgz",
+          "integrity": "sha512-s3EjZZt7xa4BkLknJZ98QGoIza94rVjaEed0rzZ/jB9WrIuu/1+tjvYCWzVrystXtDswy7TPBeIepyXwSYa4WQ==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/address": "^5.4.0",
+            "@ethersproject/bignumber": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/constants": "^5.4.0",
+            "@ethersproject/keccak256": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0",
+            "@ethersproject/rlp": "^5.4.0",
+            "@ethersproject/signing-key": "^5.4.0"
+          }
+        },
+        "@ethersproject/web": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.4.0.tgz",
+          "integrity": "sha512-1bUusGmcoRLYgMn6c1BLk1tOKUIFuTg8j+6N8lYlbMpDesnle+i3pGSagGNvwjaiLo4Y5gBibwctpPRmjrh4Og==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/base64": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0",
+            "@ethersproject/strings": "^5.4.0"
+          }
+        }
       }
     },
     "@nomiclabs/hardhat-ethers": {
@@ -793,14 +2232,14 @@
       "integrity": "sha512-QZSvbYqNpU/x60vARhq/jghh97VWjml3NAlKfu4u1XehvpEBbHVXJyKTBSZtZY7jviG305jOczEisnN8VeOMcw=="
     },
     "@openzeppelin/contracts-upgradeable2": {
-      "version": "npm:@openzeppelin/contracts-upgradeable@3.4.1",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-3.4.1.tgz",
-      "integrity": "sha512-wBGlUzEkOxcj/ghtcF2yKc8ZYh+PTUtm1mK38zoENulJ6aplij7eH8quo3lMugfzPJy+V6V5qI8QhdQmCn7hkQ=="
+      "version": "npm:@openzeppelin/contracts-upgradeable@3.4.2",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-3.4.2.tgz",
+      "integrity": "sha512-mDlBS17ymb2wpaLcrqRYdnBAmP1EwqhOXMvqWk2c5Q1N1pm5TkiCtXM9Xzznh4bYsQBq0aIWEkFFE2+iLSN1Tw=="
     },
     "@openzeppelin/contracts2": {
-      "version": "npm:@openzeppelin/contracts@3.4.1",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-3.4.1.tgz",
-      "integrity": "sha512-cUriqMauq1ylzP2TxePNdPqkwI7Le3Annh4K9rrpvKfSBB/bdW+Iu1ihBaTIABTAAJ85LmKL5SSPPL9ry8d1gQ=="
+      "version": "npm:@openzeppelin/contracts@3.4.2",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-3.4.2.tgz",
+      "integrity": "sha512-z0zMCjyhhp4y7XKAcDAi3Vgms4T2PstwBdahiO0+9NaGICQKjynK3wduSRplTgk4LXmoO1yfDGO5RbjKYxtuxA=="
     },
     "@openzeppelin/hardhat-upgrades": {
       "version": "1.9.0",
@@ -1053,9 +2492,9 @@
       }
     },
     "@types/abstract-leveldown": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@types/abstract-leveldown/-/abstract-leveldown-5.0.1.tgz",
-      "integrity": "sha512-wYxU3kp5zItbxKmeRYCEplS2MW7DzyBnxPGj+GJVHZEUZiK/nn5Ei1sUFgURDh+X051+zsGe28iud3oHjrYWQQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@types/abstract-leveldown/-/abstract-leveldown-5.0.2.tgz",
+      "integrity": "sha512-+jA1XXF3jsz+Z7FcuiNqgK53hTa/luglT2TyTpKPqoYbxVY+mCPF22Rm+q3KPBrMHJwNXFrTViHszBOfU4vftQ==",
       "dev": true
     },
     "@types/bn.js": {
@@ -1090,20 +2529,27 @@
         "@types/node": "*"
       }
     },
+    "@types/level-errors": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/level-errors/-/level-errors-3.0.0.tgz",
+      "integrity": "sha512-/lMtoq/Cf/2DVOm6zE6ORyOM+3ZVm/BvzEZVxUhf6bgh8ZHglXlBqxbxSlJeVp8FCbD3IVvk/VbsaNmDjrQvqQ==",
+      "dev": true
+    },
     "@types/levelup": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@types/levelup/-/levelup-4.3.1.tgz",
-      "integrity": "sha512-n//PeTpbHLjMLTIgW5B/g06W/6iuTBHuvUka2nFL9APMSVMNe2r4enADfu3CIE9IyV9E+uquf9OEQQqrDeg24A==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@types/levelup/-/levelup-4.3.3.tgz",
+      "integrity": "sha512-K+OTIjJcZHVlZQN1HmU64VtrC0jC3dXWQozuEIR9zVvltIk90zaGPM2AgT+fIkChpzHhFE3YnvFLCbLtzAmexA==",
       "dev": true,
       "requires": {
         "@types/abstract-leveldown": "*",
+        "@types/level-errors": "*",
         "@types/node": "*"
       }
     },
     "@types/lru-cache": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.0.tgz",
-      "integrity": "sha512-RaE0B+14ToE4l6UqdarKPnXwVDuigfFv+5j9Dze/Nqr23yyuqdNvzcZi3xB+3Agvi5R4EOgAksfv3lXX4vBt9w==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw==",
       "dev": true
     },
     "@types/mkdirp": {
@@ -1957,9 +3403,9 @@
       "dev": true
     },
     "core-js-pure": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.15.1.tgz",
-      "integrity": "sha512-OZuWHDlYcIda8sJLY4Ec6nWq2hRjlyCqCZ+jCflyleMkVt3tPedDVErvHslyS2nbO+SlBFMSBJYvtLMwxnrzjA==",
+      "version": "3.17.2",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.17.2.tgz",
+      "integrity": "sha512-2VV7DlIbooyTI7Bh+yzOOWL9tGwLnQKHno7qATE+fqZzDKYr6llVjVQOzpD/QLZFgXDPb8T71pJokHEZHEYJhQ==",
       "dev": true
     },
     "core-util-is": {
@@ -2733,41 +4179,254 @@
       }
     },
     "ethers": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.3.1.tgz",
-      "integrity": "sha512-xCKmC0gsZ9gks89ZfK3B1y6LlPdvX5fxDtu9SytnpdDJR1M7pmJI+4H0AxQPMgUYr7GtQdmECLR0gWdJQ+lZYw==",
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.4.6.tgz",
+      "integrity": "sha512-F7LXARyB/Px3AQC6/QKedWZ8eqCkgOLORqL4B/F0Mag/K+qJSFGqsR36EaOZ6fKg3ZonI+pdbhb4A8Knt/43jQ==",
       "dev": true,
       "requires": {
-        "@ethersproject/abi": "5.3.1",
-        "@ethersproject/abstract-provider": "5.3.0",
-        "@ethersproject/abstract-signer": "5.3.0",
-        "@ethersproject/address": "5.3.0",
-        "@ethersproject/base64": "5.3.0",
-        "@ethersproject/basex": "5.3.0",
-        "@ethersproject/bignumber": "5.3.0",
-        "@ethersproject/bytes": "5.3.0",
-        "@ethersproject/constants": "5.3.0",
-        "@ethersproject/contracts": "5.3.0",
-        "@ethersproject/hash": "5.3.0",
-        "@ethersproject/hdnode": "5.3.0",
-        "@ethersproject/json-wallets": "5.3.0",
-        "@ethersproject/keccak256": "5.3.0",
-        "@ethersproject/logger": "5.3.0",
-        "@ethersproject/networks": "5.3.1",
-        "@ethersproject/pbkdf2": "5.3.0",
-        "@ethersproject/properties": "5.3.0",
-        "@ethersproject/providers": "5.3.1",
-        "@ethersproject/random": "5.3.0",
-        "@ethersproject/rlp": "5.3.0",
-        "@ethersproject/sha2": "5.3.0",
-        "@ethersproject/signing-key": "5.3.0",
-        "@ethersproject/solidity": "5.3.0",
-        "@ethersproject/strings": "5.3.0",
-        "@ethersproject/transactions": "5.3.0",
-        "@ethersproject/units": "5.3.0",
-        "@ethersproject/wallet": "5.3.0",
-        "@ethersproject/web": "5.3.0",
-        "@ethersproject/wordlists": "5.3.0"
+        "@ethersproject/abi": "5.4.1",
+        "@ethersproject/abstract-provider": "5.4.1",
+        "@ethersproject/abstract-signer": "5.4.1",
+        "@ethersproject/address": "5.4.0",
+        "@ethersproject/base64": "5.4.0",
+        "@ethersproject/basex": "5.4.0",
+        "@ethersproject/bignumber": "5.4.1",
+        "@ethersproject/bytes": "5.4.0",
+        "@ethersproject/constants": "5.4.0",
+        "@ethersproject/contracts": "5.4.1",
+        "@ethersproject/hash": "5.4.0",
+        "@ethersproject/hdnode": "5.4.0",
+        "@ethersproject/json-wallets": "5.4.0",
+        "@ethersproject/keccak256": "5.4.0",
+        "@ethersproject/logger": "5.4.1",
+        "@ethersproject/networks": "5.4.2",
+        "@ethersproject/pbkdf2": "5.4.0",
+        "@ethersproject/properties": "5.4.1",
+        "@ethersproject/providers": "5.4.5",
+        "@ethersproject/random": "5.4.0",
+        "@ethersproject/rlp": "5.4.0",
+        "@ethersproject/sha2": "5.4.0",
+        "@ethersproject/signing-key": "5.4.0",
+        "@ethersproject/solidity": "5.4.0",
+        "@ethersproject/strings": "5.4.0",
+        "@ethersproject/transactions": "5.4.0",
+        "@ethersproject/units": "5.4.0",
+        "@ethersproject/wallet": "5.4.0",
+        "@ethersproject/web": "5.4.0",
+        "@ethersproject/wordlists": "5.4.0"
+      },
+      "dependencies": {
+        "@ethersproject/abi": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.4.1.tgz",
+          "integrity": "sha512-9mhbjUk76BiSluiiW4BaYyI58KSbDMMQpCLdsAR+RsT2GyATiNYxVv+pGWRrekmsIdY3I+hOqsYQSTkc8L/mcg==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/address": "^5.4.0",
+            "@ethersproject/bignumber": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/constants": "^5.4.0",
+            "@ethersproject/hash": "^5.4.0",
+            "@ethersproject/keccak256": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0",
+            "@ethersproject/strings": "^5.4.0"
+          }
+        },
+        "@ethersproject/abstract-provider": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.4.1.tgz",
+          "integrity": "sha512-3EedfKI3LVpjSKgAxoUaI+gB27frKsxzm+r21w9G60Ugk+3wVLQwhi1LsEJAKNV7WoZc8CIpNrATlL1QFABjtQ==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/networks": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0",
+            "@ethersproject/transactions": "^5.4.0",
+            "@ethersproject/web": "^5.4.0"
+          }
+        },
+        "@ethersproject/abstract-signer": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.4.1.tgz",
+          "integrity": "sha512-SkkFL5HVq1k4/25dM+NWP9MILgohJCgGv5xT5AcRruGz4ILpfHeBtO/y6j+Z3UN/PAjDeb4P7E51Yh8wcGNLGA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/abstract-provider": "^5.4.0",
+            "@ethersproject/bignumber": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0"
+          }
+        },
+        "@ethersproject/address": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.4.0.tgz",
+          "integrity": "sha512-SD0VgOEkcACEG/C6xavlU1Hy3m5DGSXW3CUHkaaEHbAPPsgi0coP5oNPsxau8eTlZOk/bpa/hKeCNoK5IzVI2Q==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/keccak256": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/rlp": "^5.4.0"
+          }
+        },
+        "@ethersproject/base64": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.4.0.tgz",
+          "integrity": "sha512-CjQw6E17QDSSC5jiM9YpF7N1aSCHmYGMt9bWD8PWv6YPMxjsys2/Q8xLrROKI3IWJ7sFfZ8B3flKDTM5wlWuZQ==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0"
+          }
+        },
+        "@ethersproject/bignumber": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.1.tgz",
+          "integrity": "sha512-fJhdxqoQNuDOk6epfM7yD6J8Pol4NUCy1vkaGAkuujZm0+lNow//MKu1hLhRiYV4BsOHyBv5/lsTjF+7hWwhJg==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "bn.js": "^4.11.9"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.4.0.tgz",
+          "integrity": "sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.4.0.tgz",
+          "integrity": "sha512-tzjn6S7sj9+DIIeKTJLjK9WGN2Tj0P++Z8ONEIlZjyoTkBuODN+0VfhAyYksKi43l1Sx9tX2VlFfzjfmr5Wl3Q==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bignumber": "^5.4.0"
+          }
+        },
+        "@ethersproject/hash": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.4.0.tgz",
+          "integrity": "sha512-xymAM9tmikKgbktOCjW60Z5sdouiIIurkZUr9oW5NOex5uwxrbsYG09kb5bMcNjlVeJD3yPivTNzViIs1GCbqA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/abstract-signer": "^5.4.0",
+            "@ethersproject/address": "^5.4.0",
+            "@ethersproject/bignumber": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/keccak256": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0",
+            "@ethersproject/strings": "^5.4.0"
+          }
+        },
+        "@ethersproject/keccak256": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.4.0.tgz",
+          "integrity": "sha512-FBI1plWet+dPUvAzPAeHzRKiPpETQzqSUWR1wXJGHVWi4i8bOSrpC3NwpkPjgeXG7MnugVc1B42VbfnQikyC/A==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "js-sha3": "0.5.7"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.1.tgz",
+          "integrity": "sha512-DZ+bRinnYLPw1yAC64oRl0QyVZj43QeHIhVKfD/+YwSz4wsv1pfwb5SOFjz+r710YEWzU6LrhuSjpSO+6PeE4A==",
+          "dev": true
+        },
+        "@ethersproject/networks": {
+          "version": "5.4.2",
+          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.4.2.tgz",
+          "integrity": "sha512-eekOhvJyBnuibfJnhtK46b8HimBc5+4gqpvd1/H9LEl7Q7/qhsIhM81dI9Fcnjpk3jB1aTy6bj0hz3cifhNeYw==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/properties": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.4.1.tgz",
+          "integrity": "sha512-cyCGlF8wWlIZyizsj2PpbJ9I7rIlUAfnHYwy/T90pdkSn/NFTa5YWZx2wTJBe9V7dD65dcrrEMisCRUJiq6n3w==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/rlp": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.4.0.tgz",
+          "integrity": "sha512-0I7MZKfi+T5+G8atId9QaQKHRvvasM/kqLyAH4XxBCBchAooH2EX5rL9kYZWwcm3awYV+XC7VF6nLhfeQFKVPg==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/signing-key": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.4.0.tgz",
+          "integrity": "sha512-q8POUeywx6AKg2/jX9qBYZIAmKSB4ubGXdQ88l40hmATj29JnG5pp331nAWwwxPn2Qao4JpWHNZsQN+bPiSW9A==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0",
+            "bn.js": "^4.11.9",
+            "elliptic": "6.5.4",
+            "hash.js": "1.1.7"
+          }
+        },
+        "@ethersproject/strings": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.4.0.tgz",
+          "integrity": "sha512-k/9DkH5UGDhv7aReXLluFG5ExurwtIpUfnDNhQA29w896Dw3i4uDTz01Quaptbks1Uj9kI8wo9tmW73wcIEaWA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/constants": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0"
+          }
+        },
+        "@ethersproject/transactions": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.4.0.tgz",
+          "integrity": "sha512-s3EjZZt7xa4BkLknJZ98QGoIza94rVjaEed0rzZ/jB9WrIuu/1+tjvYCWzVrystXtDswy7TPBeIepyXwSYa4WQ==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/address": "^5.4.0",
+            "@ethersproject/bignumber": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/constants": "^5.4.0",
+            "@ethersproject/keccak256": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0",
+            "@ethersproject/rlp": "^5.4.0",
+            "@ethersproject/signing-key": "^5.4.0"
+          }
+        },
+        "@ethersproject/web": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.4.0.tgz",
+          "integrity": "sha512-1bUusGmcoRLYgMn6c1BLk1tOKUIFuTg8j+6N8lYlbMpDesnle+i3pGSagGNvwjaiLo4Y5gBibwctpPRmjrh4Og==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/base64": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0",
+            "@ethersproject/strings": "^5.4.0"
+          }
+        }
       }
     },
     "ethjs-unit": {
@@ -2944,9 +4603,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
-      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==",
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.3.tgz",
+      "integrity": "sha512-3MkHxknWMUtb23apkgz/83fDoe+y+qr0TdgacGIA7bew+QLBo3vdgEN2xEsuXNivpFy4CyDhBBZnNZOtalmenw==",
       "dev": true
     },
     "for-each": {
@@ -12018,16 +13677,16 @@
       }
     },
     "hardhat": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.4.1.tgz",
-      "integrity": "sha512-vwllrFypukeE/Q+4ZfWj7j7nUo4ncUhRpsAYUM0Ruuuk6pQlKmRa0A6c0kxRSvvVgQsMud6j+/weYhbMX1wPmQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.6.2.tgz",
+      "integrity": "sha512-83kCYIrkRq+vrsjOLIv349fbMpL7Vp/ZGpWtu+KLMH3wcAAs+aMsABZJ8W5hb5uo69+06KeF0pCHQ6y8tBAcwA==",
       "dev": true,
       "requires": {
-        "@ethereumjs/block": "^3.3.0",
-        "@ethereumjs/blockchain": "^5.3.0",
-        "@ethereumjs/common": "^2.3.1",
-        "@ethereumjs/tx": "^3.2.1",
-        "@ethereumjs/vm": "^5.3.2",
+        "@ethereumjs/block": "^3.4.0",
+        "@ethereumjs/blockchain": "^5.4.0",
+        "@ethereumjs/common": "^2.4.0",
+        "@ethereumjs/tx": "^3.3.0",
+        "@ethereumjs/vm": "^5.5.2",
         "@ethersproject/abi": "^5.1.2",
         "@sentry/node": "^5.18.1",
         "@solidity-parser/parser": "^0.11.0",
@@ -12045,7 +13704,7 @@
         "eth-sig-util": "^2.5.2",
         "ethereum-cryptography": "^0.1.2",
         "ethereumjs-abi": "^0.6.8",
-        "ethereumjs-util": "^7.0.10",
+        "ethereumjs-util": "^7.1.0",
         "find-up": "^2.1.0",
         "fp-ts": "1.19.3",
         "fs-extra": "^7.0.1",
@@ -12072,6 +13731,12 @@
         "ws": "^7.4.6"
       },
       "dependencies": {
+        "bn.js": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+          "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
+          "dev": true
+        },
         "chalk": {
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -12088,6 +13753,20 @@
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
           "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "dev": true
+        },
+        "ethereumjs-util": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.0.tgz",
+          "integrity": "sha512-kR+vhu++mUDARrsMMhsjjzPduRVAeundLGXucGRHF3B4oEltOUspfgCVco4kckucj3FMlLaZHUl9n7/kdmr6Tw==",
+          "dev": true,
+          "requires": {
+            "@types/bn.js": "^5.1.0",
+            "bn.js": "^5.1.2",
+            "create-hash": "^1.1.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "0.1.6",
+            "rlp": "^2.2.4"
+          }
         },
         "find-up": {
           "version": "2.1.0",
@@ -12398,9 +14077,9 @@
       "dev": true
     },
     "immutable": {
-      "version": "4.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0-rc.12.tgz",
-      "integrity": "sha512-0M2XxkZLx/mi3t8NVwIm1g8nHoEmM9p9UBl/G9k4+hm0kBgOVdMV/B3CY5dQ8qG8qc80NN4gDV4HQv6FTJ5q7A==",
+      "version": "4.0.0-rc.14",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0-rc.14.tgz",
+      "integrity": "sha512-pfkvmRKJSoW7JFx0QeYlAmT+kNYvn5j0u7bnpNq4N2RCvHSTlLT208G8jgaquNe+Q8kCPHKOSpxJkyvLDpYq0w==",
       "dev": true
     },
     "import-fresh": {
@@ -13025,18 +14704,40 @@
       "dev": true
     },
     "merkle-patricia-tree": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-4.2.0.tgz",
-      "integrity": "sha512-0sBVXs7z1Q1/kxzWZ3nPnxSPiaHKF/f497UQzt9O7isRcS10tel9jM/4TivF6Jv7V1yFq4bWyoATxbDUOen5vQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-4.2.1.tgz",
+      "integrity": "sha512-25reMgrT8PhJy0Ba0U7fMZD2oobS1FPWB9vQa0uBpJYIQYYuFXEHoqEkTqA/UzX+s9br3pmUVVY/TOsFt/x0oQ==",
       "dev": true,
       "requires": {
         "@types/levelup": "^4.3.0",
-        "ethereumjs-util": "^7.0.10",
+        "ethereumjs-util": "^7.1.0",
         "level-mem": "^5.0.1",
         "level-ws": "^2.0.0",
         "readable-stream": "^3.6.0",
         "rlp": "^2.2.4",
         "semaphore-async-await": "^1.5.1"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+          "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
+          "dev": true
+        },
+        "ethereumjs-util": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.0.tgz",
+          "integrity": "sha512-kR+vhu++mUDARrsMMhsjjzPduRVAeundLGXucGRHF3B4oEltOUspfgCVco4kckucj3FMlLaZHUl9n7/kdmr6Tw==",
+          "dev": true,
+          "requires": {
+            "@types/bn.js": "^5.1.0",
+            "bn.js": "^5.1.2",
+            "create-hash": "^1.1.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "0.1.6",
+            "rlp": "^2.2.4"
+          }
+        }
       }
     },
     "micromatch": {
@@ -14999,9 +16700,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz",
-      "integrity": "sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
+      "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
       "dev": true
     },
     "typical": {

--- a/package.json
+++ b/package.json
@@ -35,15 +35,15 @@
     "dotenv": "^10.0.0"
   },
   "devDependencies": {
-    "@nomiclabs/hardhat-etherscan": "^2.1.2",
     "@nomiclabs/hardhat-ethers": "^2.0.1",
+    "@nomiclabs/hardhat-etherscan": "^2.1.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
-    "hardhat": "^2.0.8",
-    "hardhat-gas-reporter": "^1.0.4",
-    "ethers": "^5.0.29",
     "chai": "^4.3.0",
     "eslint": "^7.20.0",
     "ethereum-waffle": "^3.2.2",
+    "ethers": "^5.4.6",
+    "hardhat": "^2.6.2",
+    "hardhat-gas-reporter": "^1.0.4",
     "prettier": "2.2.1",
     "prettier-plugin-solidity": "^1.0.0-beta.5",
     "solhint-plugin-prettier": "^0.0.5"

--- a/test/Bid.test.js
+++ b/test/Bid.test.js
@@ -49,24 +49,34 @@ describe('Bid', async () => {
             if (placedByPartyBid && success) {
               it('Allows PartyBid to bid', async () => {
                 const { signerIndex } = contributions[0];
-                await expect(bidThroughParty(partyBid, signers[signerIndex])).to.emit(partyBid, 'Bid');
+                await expect(
+                  bidThroughParty(partyBid, signers[signerIndex]),
+                ).to.emit(partyBid, 'Bid');
               });
 
               it('Does not allow PartyBid to bid twice', async () => {
                 const { signerIndex } = contributions[0];
-                await expect(bidThroughParty(partyBid, signers[signerIndex])).to.be.revertedWith("PartyBid::bid: already highest bidder");
+                await expect(
+                  bidThroughParty(partyBid, signers[signerIndex]),
+                ).to.be.revertedWith('PartyBid::bid: already highest bidder');
               });
             } else if (placedByPartyBid && !success) {
               it('Does not allow PartyBid to bid', async () => {
                 const { signerIndex } = contributions[0];
-                await expect(bidThroughParty(partyBid, signers[signerIndex])).to.be.reverted;
+                await expect(bidThroughParty(partyBid, signers[signerIndex])).to
+                  .be.reverted;
               });
             } else if (!placedByPartyBid && success) {
               it('Accepts external bid', async () => {
-                const eventName =
-                  marketName == MARKET_NAMES.FOUNDATION
-                    ? 'ReserveAuctionBidPlaced'
-                    : 'AuctionBid';
+                let eventName;
+                if (marketName == MARKET_NAMES.FOUNDATION) {
+                  eventName = 'ReserveAuctionBidPlaced';
+                } else if (marketName == MARKET_NAMES.FRACTIONAL) {
+                  const auctionState = await market.auctionState();
+                  eventName = auctionState === 0 ? 'Start' : 'Bid';
+                } else {
+                  eventName = 'AuctionBid';
+                }
                 await expect(
                   placeBid(
                     signers[0],

--- a/test/Claim.test.js
+++ b/test/Claim.test.js
@@ -4,13 +4,15 @@ const { waffle } = require('hardhat');
 const { provider } = waffle;
 const { expect } = require('chai');
 // ============ Internal Imports ============
-const { eth, getBalances, bidThroughParty, contribute } = require('./helpers/utils');
+const {
+  eth,
+  getBalances,
+  bidThroughParty,
+  contribute,
+} = require('./helpers/utils');
 const { placeBid } = require('./helpers/externalTransactions');
 const { deployTestContractSetup, getTokenVault } = require('./helpers/deploy');
-const {
-  MARKETS,
-  FOURTY_EIGHT_HOURS_IN_SECONDS,
-} = require('./helpers/constants');
+const { MARKETS, SEVEN_DAYS_IN_SECONDS } = require('./helpers/constants');
 const { testCases } = require('./testCases.json');
 
 describe('Claim', async () => {
@@ -73,9 +75,7 @@ describe('Claim', async () => {
 
           it('Allows Finalize', async () => {
             // increase time on-chain so that auction can be finalized
-            await provider.send('evm_increaseTime', [
-              FOURTY_EIGHT_HOURS_IN_SECONDS,
-            ]);
+            await provider.send('evm_increaseTime', [SEVEN_DAYS_IN_SECONDS]);
             await provider.send('evm_mine');
 
             // finalize auction

--- a/test/Contribute.test.js
+++ b/test/Contribute.test.js
@@ -39,7 +39,11 @@ describe('Contribute', async () => {
           });
 
           it('Does not accept a 0 contribution', async () => {
-            await expect(contribute(partyBid, signers[0], eth(0))).to.be.revertedWith("PartyBid::contribute: must contribute more than 0");
+            await expect(
+              contribute(partyBid, signers[0], eth(0)),
+            ).to.be.revertedWith(
+              'PartyBid::contribute: must contribute more than 0',
+            );
           });
 
           // submit each contribution & check test conditions

--- a/test/Finalize.test.js
+++ b/test/Finalize.test.js
@@ -13,10 +13,7 @@ const {
 } = require('./helpers/utils');
 const { placeBid } = require('./helpers/externalTransactions');
 const { deployTestContractSetup, getTokenVault } = require('./helpers/deploy');
-const {
-  PARTY_STATUS,
-  FOURTY_EIGHT_HOURS_IN_SECONDS,
-} = require('./helpers/constants');
+const { PARTY_STATUS, SEVEN_DAYS_IN_SECONDS } = require('./helpers/constants');
 const { MARKETS } = require('./helpers/constants');
 const { testCases } = require('./testCases.json');
 
@@ -31,7 +28,7 @@ describe('Finalize', async () => {
             contributions,
             bids,
             finalBid,
-            finalFee
+            finalFee,
           } = testCase;
           // instantiate test vars
           let partyBid,
@@ -103,9 +100,7 @@ describe('Finalize', async () => {
 
           it('Does allow Finalize after the auction is over', async () => {
             // increase time on-chain so that auction can be finalized
-            await provider.send('evm_increaseTime', [
-              FOURTY_EIGHT_HOURS_IN_SECONDS,
-            ]);
+            await provider.send('evm_increaseTime', [SEVEN_DAYS_IN_SECONDS]);
             await provider.send('evm_mine');
 
             // finalize auction
@@ -115,11 +110,15 @@ describe('Finalize', async () => {
           });
 
           it(`Doesn't accept contributions after Finalize`, async () => {
-            await expect(contribute(partyBid, signers[0], eth(1))).to.be.revertedWith("PartyBid::contribute: auction not active");
+            await expect(
+              contribute(partyBid, signers[0], eth(1)),
+            ).to.be.revertedWith('PartyBid::contribute: auction not active');
           });
 
           it(`Doesn't accept bids after Finalize`, async () => {
-            await expect(bidThroughParty(partyBid, signers[0])).to.be.revertedWith("PartyBid::bid: auction not active");
+            await expect(
+              bidThroughParty(partyBid, signers[0]),
+            ).to.be.revertedWith('PartyBid::bid: auction not active');
           });
 
           if (partyBidWins) {
@@ -135,7 +134,8 @@ describe('Finalize', async () => {
             });
 
             it('Has correct totalSpent, totalSupply of tokens, balanceOf PartyBid tokens, and ETH balance', async () => {
-              const expectedTotalSpent = finalBid[marketName] + finalFee[marketName];
+              const expectedTotalSpent =
+                finalBid[marketName] + finalFee[marketName];
               const expectedTotalSupply = expectedTotalSpent * 1000;
 
               const totalSpent = await partyBid.totalSpent();

--- a/test/custom/AuctionCanceled.test.js
+++ b/test/custom/AuctionCanceled.test.js
@@ -4,147 +4,140 @@ const { waffle } = require('hardhat');
 const { provider } = waffle;
 const { expect } = require('chai');
 // ============ Internal Imports ============
-const {
-    eth,
-    weiToEth,
-    contribute,
-} = require('../helpers/utils');
-const {
-    cancelAuction
-} = require('../helpers/externalTransactions');
+const { eth, weiToEth, contribute } = require('../helpers/utils');
+const { cancelAuction } = require('../helpers/externalTransactions');
 const { deployTestContractSetup } = require('../helpers/deploy');
-const {
-    PARTY_STATUS,
-} = require('../helpers/constants');
+const { PARTY_STATUS } = require('../helpers/constants');
 const { MARKETS, MARKET_NAMES } = require('../helpers/constants');
 const { testCases } = require('../testCases.json');
 
 describe('Auction Canceled', async () => {
-    // Noun auctions cannot be cancelled
-    MARKETS.filter(m => m !== MARKET_NAMES.NOUNS).map((marketName) => {
-        describe(marketName, async () => {
-            testCases.map((testCase, i) => {
-                describe(`Case ${i}`, async () => {
-                    // get test case information
-                    const {
-                        auctionReservePrice,
-                        contributions,
-                        claims
-                    } = testCase;
-                    // instantiate test vars
-                    let partyBid,
-                        market,
-                        nftContract,
-                        partyDAOMultisig,
-                        auctionId,
-                        multisigBalanceBefore;
-                    const signers = provider.getWallets();
-                    const tokenId = 100;
-                    const artistSigner = signers[0];
+  // Noun auctions cannot be cancelled
+  // Fractional auctions cannot be stopped, once initiated
+  MARKETS.filter(
+    (m) => m !== MARKET_NAMES.NOUNS && m !== MARKET_NAMES.FRACTIONAL,
+  ).map((marketName) => {
+    describe(marketName, async () => {
+      testCases.map((testCase, i) => {
+        describe(`Case ${i}`, async () => {
+          // get test case information
+          const { auctionReservePrice, contributions, claims } = testCase;
+          // instantiate test vars
+          let partyBid,
+            market,
+            nftContract,
+            partyDAOMultisig,
+            auctionId,
+            multisigBalanceBefore;
+          const signers = provider.getWallets();
+          const tokenId = 100;
+          const artistSigner = signers[0];
 
-                    before(async () => {
-                        // DEPLOY NFT, MARKET, AND PARTY BID CONTRACTS
-                        const contracts = await deployTestContractSetup(
-                            marketName,
-                            provider,
-                            artistSigner,
-                            tokenId,
-                            auctionReservePrice,
-                        );
-                        partyBid = contracts.partyBid;
-                        market = contracts.market;
-                        partyDAOMultisig = contracts.partyDAOMultisig;
-                        nftContract = contracts.nftContract;
+          before(async () => {
+            // DEPLOY NFT, MARKET, AND PARTY BID CONTRACTS
+            const contracts = await deployTestContractSetup(
+              marketName,
+              provider,
+              artistSigner,
+              tokenId,
+              auctionReservePrice,
+            );
+            partyBid = contracts.partyBid;
+            market = contracts.market;
+            partyDAOMultisig = contracts.partyDAOMultisig;
+            nftContract = contracts.nftContract;
 
-                        auctionId = await partyBid.auctionId();
+            auctionId = await partyBid.auctionId();
 
-                        multisigBalanceBefore = await provider.getBalance(
-                            partyDAOMultisig.address,
-                        );
+            multisigBalanceBefore = await provider.getBalance(
+              partyDAOMultisig.address,
+            );
 
-                        // submit contributions before bidding begins
-                        for (let contribution of contributions) {
-                            const { signerIndex, amount } = contribution;
-                            const signer = signers[signerIndex];
-                            await contribute(partyBid, signer, eth(amount));
-                        }
-                    });
+            // submit contributions before bidding begins
+            for (let contribution of contributions) {
+              const { signerIndex, amount } = contribution;
+              const signer = signers[signerIndex];
+              await contribute(partyBid, signer, eth(amount));
+            }
+          });
 
-                    it('Does not allow Finalize before the auction is over', async () => {
-                        await expect(partyBid.finalize()).to.be.reverted;
-                    });
+          it('Does not allow Finalize before the auction is over', async () => {
+            await expect(partyBid.finalize()).to.be.reverted;
+          });
 
-                    it('Is ACTIVE before auction is canceled', async () => {
-                        const partyStatus = await partyBid.partyStatus();
-                        expect(partyStatus).to.equal(PARTY_STATUS.AUCTION_ACTIVE);
-                    });
+          it('Is ACTIVE before auction is canceled', async () => {
+            const partyStatus = await partyBid.partyStatus();
+            expect(partyStatus).to.equal(PARTY_STATUS.AUCTION_ACTIVE);
+          });
 
-                    it('Allows artist to cancel auction', async () => {
-                        await expect(cancelAuction(artistSigner, market, auctionId, marketName)).to.not.be.reverted;
-                    });
+          it('Allows artist to cancel auction', async () => {
+            await expect(
+              cancelAuction(artistSigner, market, auctionId, marketName),
+            ).to.not.be.reverted;
+          });
 
-                    it('Is ACTIVE before PartyBid-level Finalize', async () => {
-                        const partyStatus = await partyBid.partyStatus();
-                        expect(partyStatus).to.equal(PARTY_STATUS.AUCTION_ACTIVE);
-                    });
+          it('Is ACTIVE before PartyBid-level Finalize', async () => {
+            const partyStatus = await partyBid.partyStatus();
+            expect(partyStatus).to.equal(PARTY_STATUS.AUCTION_ACTIVE);
+          });
 
-                    it('Allows PartyBid Finalize after auction is canceled', async () => {
-                        // finalize auction
-                        await expect(partyBid.finalize()).to.emit(partyBid, 'Finalized');
-                    });
+          it('Allows PartyBid Finalize after auction is canceled', async () => {
+            // finalize auction
+            await expect(partyBid.finalize()).to.emit(partyBid, 'Finalized');
+          });
 
-                    it(`Is LOST after Finalize`, async () => {
-                        const partyStatus = await partyBid.partyStatus();
-                        expect(partyStatus).to.equal(PARTY_STATUS.AUCTION_LOST);
-                    });
+          it(`Is LOST after Finalize`, async () => {
+            const partyStatus = await partyBid.partyStatus();
+            expect(partyStatus).to.equal(PARTY_STATUS.AUCTION_LOST);
+          });
 
-                    it(`Does not own the NFT`, async () => {
-                        const owner = await nftContract.ownerOf(tokenId);
-                        expect(owner).to.not.equal(partyBid.address);
-                    });
+          it(`Does not own the NFT`, async () => {
+            const owner = await nftContract.ownerOf(tokenId);
+            expect(owner).to.not.equal(partyBid.address);
+          });
 
-                    it('Has zero totalSpent', async () => {
-                        const totalSpent = await partyBid.totalSpent();
-                        expect(totalSpent).to.equal(0);
-                    });
+          it('Has zero totalSpent', async () => {
+            const totalSpent = await partyBid.totalSpent();
+            expect(totalSpent).to.equal(0);
+          });
 
-                    it(`Did not transfer fee to multisig`, async () => {
-                        const multisigBalanceAfter = await provider.getBalance(
-                            partyDAOMultisig.address,
-                        );
-                        expect(multisigBalanceAfter).to.equal(multisigBalanceBefore);
-                    });
+          it(`Did not transfer fee to multisig`, async () => {
+            const multisigBalanceAfter = await provider.getBalance(
+              partyDAOMultisig.address,
+            );
+            expect(multisigBalanceAfter).to.equal(multisigBalanceBefore);
+          });
 
-                    for (let claim of claims[marketName]) {
-                        const { signerIndex, totalContributed } = claim;
-                        const contributor = signers[signerIndex];
-                        it(`Allows contributors to claim the total they contributed`, async () => {
-                            const partyBidBalanceBefore = await provider.getBalance(
-                                partyBid.address,
-                            );
+          for (let claim of claims[marketName]) {
+            const { signerIndex, totalContributed } = claim;
+            const contributor = signers[signerIndex];
+            it(`Allows contributors to claim the total they contributed`, async () => {
+              const partyBidBalanceBefore = await provider.getBalance(
+                partyBid.address,
+              );
 
-                            // claim succeeds; event is emitted
-                            await expect(partyBid.claim(contributor.address))
-                                .to.emit(partyBid, 'Claimed')
-                                .withArgs(
-                                    contributor.address,
-                                    eth(totalContributed),
-                                    eth(totalContributed),
-                                    eth(0),
-                                );
+              // claim succeeds; event is emitted
+              await expect(partyBid.claim(contributor.address))
+                .to.emit(partyBid, 'Claimed')
+                .withArgs(
+                  contributor.address,
+                  eth(totalContributed),
+                  eth(totalContributed),
+                  eth(0),
+                );
 
-                            const partyBidBalanceAfter = await provider.getBalance(
-                                partyBid.address,
-                            );
+              const partyBidBalanceAfter = await provider.getBalance(
+                partyBid.address,
+              );
 
-                            // ETH was transferred from PartyBid to contributor
-                            await expect(weiToEth(partyBidBalanceAfter)).to.equal(
-                                weiToEth(partyBidBalanceBefore) - totalContributed,
-                            );
-                        });
-                    }
-                });
+              // ETH was transferred from PartyBid to contributor
+              await expect(weiToEth(partyBidBalanceAfter)).to.equal(
+                weiToEth(partyBidBalanceBefore) - totalContributed,
+              );
             });
+          }
         });
+      });
     });
+  });
 });

--- a/test/custom/ExternalFinalize.test.js
+++ b/test/custom/ExternalFinalize.test.js
@@ -5,196 +5,197 @@ const { provider } = waffle;
 const { expect } = require('chai');
 // ============ Internal Imports ============
 const {
-    eth,
-    weiToEth,
-    getTotalContributed,
-    contribute,
-    bidThroughParty,
+  eth,
+  weiToEth,
+  getTotalContributed,
+  contribute,
+  bidThroughParty,
 } = require('../helpers/utils');
-const { placeBid, externalFinalize } = require('../helpers/externalTransactions');
-const { deployTestContractSetup, getTokenVault } = require('../helpers/deploy');
 const {
-    PARTY_STATUS,
-    FOURTY_EIGHT_HOURS_IN_SECONDS,
-} = require('../helpers/constants');
+  placeBid,
+  externalFinalize,
+} = require('../helpers/externalTransactions');
+const { deployTestContractSetup, getTokenVault } = require('../helpers/deploy');
+const { PARTY_STATUS, SEVEN_DAYS_IN_SECONDS } = require('../helpers/constants');
 const { MARKETS } = require('../helpers/constants');
 const { testCases } = require('../testCases.json');
 
 describe('External Finalize', async () => {
-    MARKETS.map((marketName) => {
-        describe(marketName, async () => {
-            testCases.map((testCase, i) => {
-                describe(`Case ${i}`, async () => {
-                    // get test case information
-                    const {
-                        auctionReservePrice,
-                        contributions,
-                        bids,
-                        finalBid,
-                        finalFee
-                    } = testCase;
-                    // instantiate test vars
-                    let partyBid,
-                        market,
-                        nftContract,
-                        partyDAOMultisig,
-                        auctionId,
-                        multisigBalanceBefore,
-                        token;
-                    const totalContributed = getTotalContributed(contributions);
-                    const lastBid = bids[bids.length - 1];
-                    const partyBidWins = lastBid.placedByPartyBid && lastBid.success;
-                    const signers = provider.getWallets();
-                    const tokenId = 95;
+  MARKETS.map((marketName) => {
+    describe(marketName, async () => {
+      testCases.map((testCase, i) => {
+        describe(`Case ${i}`, async () => {
+          // get test case information
+          const {
+            auctionReservePrice,
+            contributions,
+            bids,
+            finalBid,
+            finalFee,
+          } = testCase;
+          // instantiate test vars
+          let partyBid,
+            market,
+            nftContract,
+            partyDAOMultisig,
+            auctionId,
+            multisigBalanceBefore,
+            token;
+          const totalContributed = getTotalContributed(contributions);
+          const lastBid = bids[bids.length - 1];
+          const partyBidWins = lastBid.placedByPartyBid && lastBid.success;
+          const signers = provider.getWallets();
+          const tokenId = 95;
 
-                    before(async () => {
-                        // DEPLOY NFT, MARKET, AND PARTY BID CONTRACTS
-                        const contracts = await deployTestContractSetup(
-                            marketName,
-                            provider,
-                            signers[0],
-                            tokenId,
-                            auctionReservePrice,
-                        );
-                        partyBid = contracts.partyBid;
-                        market = contracts.market;
-                        partyDAOMultisig = contracts.partyDAOMultisig;
-                        nftContract = contracts.nftContract;
+          before(async () => {
+            // DEPLOY NFT, MARKET, AND PARTY BID CONTRACTS
+            const contracts = await deployTestContractSetup(
+              marketName,
+              provider,
+              signers[0],
+              tokenId,
+              auctionReservePrice,
+            );
+            partyBid = contracts.partyBid;
+            market = contracts.market;
+            partyDAOMultisig = contracts.partyDAOMultisig;
+            nftContract = contracts.nftContract;
 
-                        auctionId = await partyBid.auctionId();
+            auctionId = await partyBid.auctionId();
 
-                        multisigBalanceBefore = await provider.getBalance(
-                            partyDAOMultisig.address,
-                        );
+            multisigBalanceBefore = await provider.getBalance(
+              partyDAOMultisig.address,
+            );
 
-                        // submit contributions before bidding begins
-                        for (let contribution of contributions) {
-                            const { signerIndex, amount } = contribution;
-                            const signer = signers[signerIndex];
-                            await contribute(partyBid, signer, eth(amount));
-                        }
+            // submit contributions before bidding begins
+            for (let contribution of contributions) {
+              const { signerIndex, amount } = contribution;
+              const signer = signers[signerIndex];
+              await contribute(partyBid, signer, eth(amount));
+            }
 
-                        // submit the valid bids in order
-                        for (let bid of bids) {
-                            const { placedByPartyBid, amount, success } = bid;
-                            if (success && placedByPartyBid) {
-                                const { signerIndex } = contributions[0];
-                                await bidThroughParty(partyBid, signers[signerIndex]);
-                            } else if (success && !placedByPartyBid) {
-                                await placeBid(
-                                    signers[0],
-                                    market,
-                                    auctionId,
-                                    eth(amount),
-                                    marketName,
-                                );
-                            }
-                        }
-                    });
+            // submit the valid bids in order
+            for (let bid of bids) {
+              const { placedByPartyBid, amount, success } = bid;
+              if (success && placedByPartyBid) {
+                const { signerIndex } = contributions[0];
+                await bidThroughParty(partyBid, signers[signerIndex]);
+              } else if (success && !placedByPartyBid) {
+                await placeBid(
+                  signers[0],
+                  market,
+                  auctionId,
+                  eth(amount),
+                  marketName,
+                );
+              }
+            }
+          });
 
-                    it('Does not allow Finalize before the auction is over', async () => {
-                        await expect(partyBid.finalize()).to.be.reverted;
-                    });
+          it('Does not allow Finalize before the auction is over', async () => {
+            await expect(partyBid.finalize()).to.be.reverted;
+          });
 
-                    it('Is ACTIVE before auction-level Finalize', async () => {
-                        const partyStatus = await partyBid.partyStatus();
-                        expect(partyStatus).to.equal(PARTY_STATUS.AUCTION_ACTIVE);
-                    });
+          it('Is ACTIVE before auction-level Finalize', async () => {
+            const partyStatus = await partyBid.partyStatus();
+            expect(partyStatus).to.equal(PARTY_STATUS.AUCTION_ACTIVE);
+          });
 
-                    it('Accepts external Finalize', async () => {
-                        // increase time on-chain so that auction can be finalized
-                        await provider.send('evm_increaseTime', [
-                            FOURTY_EIGHT_HOURS_IN_SECONDS,
-                        ]);
-                        await provider.send('evm_mine');
+          it('Accepts external Finalize', async () => {
+            // increase time on-chain so that auction can be finalized
+            await provider.send('evm_increaseTime', [SEVEN_DAYS_IN_SECONDS]);
+            await provider.send('evm_mine');
 
-                        await expect(externalFinalize(signers[2], market, auctionId, marketName)).to.not.be.reverted;
-                    });
+            await expect(
+              externalFinalize(signers[2], market, auctionId, marketName),
+            ).to.not.be.reverted;
+          });
 
-                    it('Is ACTIVE before PartyBid-level Finalize', async () => {
-                        const partyStatus = await partyBid.partyStatus();
-                        expect(partyStatus).to.equal(PARTY_STATUS.AUCTION_ACTIVE);
-                    });
+          it('Is ACTIVE before PartyBid-level Finalize', async () => {
+            const partyStatus = await partyBid.partyStatus();
+            expect(partyStatus).to.equal(PARTY_STATUS.AUCTION_ACTIVE);
+          });
 
-                    it('Allows PartyBid Finalize after auction-level Finalize', async () => {
-                        // finalize auction
-                        await expect(partyBid.finalize()).to.emit(partyBid, 'Finalized');
+          it('Allows PartyBid Finalize after auction-level Finalize', async () => {
+            // finalize auction
+            await expect(partyBid.finalize()).to.emit(partyBid, 'Finalized');
 
-                        token = await getTokenVault(partyBid, signers[0]);
-                    });
+            token = await getTokenVault(partyBid, signers[0]);
+          });
 
-                    if (partyBidWins) {
-                        it(`Is WON after Finalize`, async () => {
-                            const partyStatus = await partyBid.partyStatus();
-                            expect(partyStatus).to.equal(PARTY_STATUS.AUCTION_WON);
-                        });
-
-                        it(`Token Vault Owns the NFT`, async () => {
-                            const vaultAddress = await partyBid.tokenVault();
-                            const owner = await nftContract.ownerOf(tokenId);
-                            expect(owner).to.equal(vaultAddress);
-                        });
-
-                        it('Has correct totalSpent, totalSupply of tokens, balanceOf PartyBid tokens, and ETH balance', async () => {
-                            const expectedTotalSpent = finalBid[marketName] + finalFee[marketName];
-                            const expectedTotalSupply = expectedTotalSpent * 1000;
-
-                            const totalSpent = await partyBid.totalSpent();
-                            expect(totalSpent).to.equal(eth(expectedTotalSpent));
-
-                            const totalSupply = await token.totalSupply();
-                            expect(totalSupply).to.equal(eth(expectedTotalSupply));
-
-                            const partyBidTokenBalance = await token.balanceOf(
-                                partyBid.address,
-                            );
-                            expect(partyBidTokenBalance).to.equal(eth(expectedTotalSupply));
-
-                            const expectedEthBalance = totalContributed - expectedTotalSpent;
-                            const ethBalance = await provider.getBalance(partyBid.address);
-                            expect(ethBalance).to.equal(eth(expectedEthBalance));
-                        });
-
-                        it(`Transferred fee to multisig`, async () => {
-                            const balanceBeforeAsFloat = parseFloat(
-                                weiToEth(multisigBalanceBefore),
-                            );
-
-                            const multisigBalanceWithFee = eth(
-                                balanceBeforeAsFloat + finalFee[marketName],
-                            );
-                            const multisigBalanceAfter = await provider.getBalance(
-                                partyDAOMultisig.address,
-                            );
-                            expect(weiToEth(multisigBalanceAfter)).to.equal(
-                                weiToEth(multisigBalanceWithFee),
-                            );
-                        });
-                    } else {
-                        it(`Is LOST after Finalize`, async () => {
-                            const partyStatus = await partyBid.partyStatus();
-                            expect(partyStatus).to.equal(PARTY_STATUS.AUCTION_LOST);
-                        });
-
-                        it(`Does not own the NFT`, async () => {
-                            const owner = await nftContract.ownerOf(tokenId);
-                            expect(owner).to.not.equal(partyBid.address);
-                        });
-
-                        it('Has zero totalSpent', async () => {
-                            const totalSpent = await partyBid.totalSpent();
-                            expect(totalSpent).to.equal(0);
-                        });
-
-                        it(`Did not transfer fee to multisig`, async () => {
-                            const multisigBalanceAfter = await provider.getBalance(
-                                partyDAOMultisig.address,
-                            );
-                            expect(multisigBalanceAfter).to.equal(multisigBalanceBefore);
-                        });
-                    }
-                });
+          if (partyBidWins) {
+            it(`Is WON after Finalize`, async () => {
+              const partyStatus = await partyBid.partyStatus();
+              expect(partyStatus).to.equal(PARTY_STATUS.AUCTION_WON);
             });
+
+            it(`Token Vault Owns the NFT`, async () => {
+              const vaultAddress = await partyBid.tokenVault();
+              const owner = await nftContract.ownerOf(tokenId);
+              expect(owner).to.equal(vaultAddress);
+            });
+
+            it('Has correct totalSpent, totalSupply of tokens, balanceOf PartyBid tokens, and ETH balance', async () => {
+              const expectedTotalSpent =
+                finalBid[marketName] + finalFee[marketName];
+              const expectedTotalSupply = expectedTotalSpent * 1000;
+
+              const totalSpent = await partyBid.totalSpent();
+              expect(totalSpent).to.equal(eth(expectedTotalSpent));
+
+              const totalSupply = await token.totalSupply();
+              expect(totalSupply).to.equal(eth(expectedTotalSupply));
+
+              const partyBidTokenBalance = await token.balanceOf(
+                partyBid.address,
+              );
+              expect(partyBidTokenBalance).to.equal(eth(expectedTotalSupply));
+
+              const expectedEthBalance = totalContributed - expectedTotalSpent;
+              const ethBalance = await provider.getBalance(partyBid.address);
+              expect(ethBalance).to.equal(eth(expectedEthBalance));
+            });
+
+            it(`Transferred fee to multisig`, async () => {
+              const balanceBeforeAsFloat = parseFloat(
+                weiToEth(multisigBalanceBefore),
+              );
+
+              const multisigBalanceWithFee = eth(
+                balanceBeforeAsFloat + finalFee[marketName],
+              );
+              const multisigBalanceAfter = await provider.getBalance(
+                partyDAOMultisig.address,
+              );
+              expect(weiToEth(multisigBalanceAfter)).to.equal(
+                weiToEth(multisigBalanceWithFee),
+              );
+            });
+          } else {
+            it(`Is LOST after Finalize`, async () => {
+              const partyStatus = await partyBid.partyStatus();
+              expect(partyStatus).to.equal(PARTY_STATUS.AUCTION_LOST);
+            });
+
+            it(`Does not own the NFT`, async () => {
+              const owner = await nftContract.ownerOf(tokenId);
+              expect(owner).to.not.equal(partyBid.address);
+            });
+
+            it('Has zero totalSpent', async () => {
+              const totalSpent = await partyBid.totalSpent();
+              expect(totalSpent).to.equal(0);
+            });
+
+            it(`Did not transfer fee to multisig`, async () => {
+              const multisigBalanceAfter = await provider.getBalance(
+                partyDAOMultisig.address,
+              );
+              expect(multisigBalanceAfter).to.equal(multisigBalanceBefore);
+            });
+          }
         });
+      });
     });
+  });
 });

--- a/test/custom/MaxOutbid.test.js
+++ b/test/custom/MaxOutbid.test.js
@@ -4,126 +4,127 @@ const { waffle } = require('hardhat');
 const { provider } = waffle;
 const { expect } = require('chai');
 // ============ Internal Imports ============
-const {
-    eth,
-    contribute,
-    bidThroughParty,
-} = require('../helpers/utils');
+const { eth, contribute, bidThroughParty } = require('../helpers/utils');
 const { placeBid } = require('../helpers/externalTransactions');
 const { deployTestContractSetup } = require('../helpers/deploy');
 const { MARKETS, MARKET_NAMES } = require('../helpers/constants');
 
 const testCases = [
-    {
-        reserve: 500,
-        balance: {
-            [MARKET_NAMES.ZORA]: 551.25,
-            [MARKET_NAMES.FOUNDATION]: 577.5,
-            [MARKET_NAMES.NOUNS]: 551.25,
-        }
+  {
+    reserve: 500,
+    balance: {
+      [MARKET_NAMES.ZORA]: 551.25,
+      [MARKET_NAMES.FOUNDATION]: 577.5,
+      [MARKET_NAMES.NOUNS]: 551.25,
+      [MARKET_NAMES.FRACTIONAL]: 551.25,
     },
-    {
-        reserve: 1,
-        balance: {
-            [MARKET_NAMES.ZORA]: 1.1025,
-            [MARKET_NAMES.FOUNDATION]: 1.155,
-            [MARKET_NAMES.NOUNS]: 1.1025,
-        }
-    }
+  },
+  {
+    reserve: 1,
+    balance: {
+      [MARKET_NAMES.ZORA]: 1.1025,
+      [MARKET_NAMES.FOUNDATION]: 1.155,
+      [MARKET_NAMES.NOUNS]: 1.1025,
+      [MARKET_NAMES.FRACTIONAL]: 1.1025,
+    },
+  },
 ];
 
 describe('Maximum Outbid', async () => {
-    MARKETS.map((marketName) => {
-        describe(marketName, async () => {
-            testCases.map((testCase, i) => {
-                // get test case information
-                const {reserve, balance} = testCase;
-                describe(`Case ${i}`, async () => {
-                    // instantiate test vars
-                    let partyBid;
-                    const signers = provider.getWallets();
-                    const tokenId = 95;
-                    const reservePrice = reserve;
+  MARKETS.map((marketName) => {
+    describe(marketName, async () => {
+      testCases.map((testCase, i) => {
+        // get test case information
+        const { reserve, balance } = testCase;
+        describe(`Case ${i}`, async () => {
+          // instantiate test vars
+          let partyBid;
+          const signers = provider.getWallets();
+          const tokenId = 95;
+          const reservePrice = reserve;
 
-                    before(async () => {
-                        // DEPLOY NFT, MARKET, AND PARTY BID CONTRACTS
-                        const contracts = await deployTestContractSetup(
-                            marketName,
-                            provider,
-                            signers[0],
-                            tokenId,
-                            reservePrice,
-                        );
-                        partyBid = contracts.partyBid;
-                        const market = contracts.market;
-                        const auctionId = await partyBid.auctionId();
+          before(async () => {
+            // DEPLOY NFT, MARKET, AND PARTY BID CONTRACTS
+            const contracts = await deployTestContractSetup(
+              marketName,
+              provider,
+              signers[0],
+              tokenId,
+              reservePrice,
+            );
+            partyBid = contracts.partyBid;
+            const market = contracts.market;
+            const auctionId = await partyBid.auctionId();
 
-                        // contribute balance to PartyBid
-                        await contribute(partyBid, signers[0], eth(balance[marketName]));
+            // contribute balance to PartyBid
+            await contribute(partyBid, signers[0], eth(balance[marketName]));
 
-                        // submit first bid from external account
-                        await placeBid(
-                            signers[0],
-                            market,
-                            auctionId,
-                            eth(reservePrice),
-                            marketName,
-                        );
-                    });
+            // submit first bid from external account
+            await placeBid(
+              signers[0],
+              market,
+              auctionId,
+              eth(reservePrice),
+              marketName,
+            );
+          });
 
-                    it(`Allows outbidding a ${reservePrice} ETH bid`, async () => {
-                        await expect(bidThroughParty(partyBid, signers[0])).to.emit(partyBid, 'Bid');
-                    });
-                });
-            });
+          it(`Allows outbidding a ${reservePrice} ETH bid`, async () => {
+            await expect(bidThroughParty(partyBid, signers[0])).to.emit(
+              partyBid,
+              'Bid',
+            );
+          });
         });
+      });
     });
+  });
 });
 
 describe('Failed Maximum Outbid', async () => {
-    MARKETS.map((marketName) => {
-        describe(marketName, async () => {
-            testCases.map((testCase, i) => {
-                // get test case information
-                const {reserve, balance} = testCase;
-                describe(`Case ${i}`, async () => {
-                    // instantiate test vars
-                    let partyBid;
-                    const signers = provider.getWallets();
-                    const tokenId = 95;
-                    const reservePrice = reserve + 0.000000000001;
+  MARKETS.map((marketName) => {
+    describe(marketName, async () => {
+      testCases.map((testCase, i) => {
+        // get test case information
+        const { reserve, balance } = testCase;
+        describe(`Case ${i}`, async () => {
+          // instantiate test vars
+          let partyBid;
+          const signers = provider.getWallets();
+          const tokenId = 95;
+          const reservePrice = reserve + 0.000000000001;
 
-                    before(async () => {
-                        // DEPLOY NFT, MARKET, AND PARTY BID CONTRACTS
-                        const contracts = await deployTestContractSetup(
-                            marketName,
-                            provider,
-                            signers[0],
-                            tokenId,
-                            reservePrice,
-                        );
-                        partyBid = contracts.partyBid;
-                        const market = contracts.market;
-                        const auctionId = await partyBid.auctionId();
+          before(async () => {
+            // DEPLOY NFT, MARKET, AND PARTY BID CONTRACTS
+            const contracts = await deployTestContractSetup(
+              marketName,
+              provider,
+              signers[0],
+              tokenId,
+              reservePrice,
+            );
+            partyBid = contracts.partyBid;
+            const market = contracts.market;
+            const auctionId = await partyBid.auctionId();
 
-                        // contribute balance to PartyBid
-                        await contribute(partyBid, signers[0], eth(balance[marketName]));
+            // contribute balance to PartyBid
+            await contribute(partyBid, signers[0], eth(balance[marketName]));
 
-                        // submit first bid from external account
-                        await placeBid(
-                            signers[0],
-                            market,
-                            auctionId,
-                            eth(reservePrice),
-                            marketName,
-                        );
-                    });
+            // submit first bid from external account
+            await placeBid(
+              signers[0],
+              market,
+              auctionId,
+              eth(reservePrice),
+              marketName,
+            );
+          });
 
-                    it(`Does not allow outbidding a ${reservePrice} ETH bid`, async () => {
-                        await expect(bidThroughParty(partyBid, signers[0])).to.be.reverted;
-                    });
-                });
-            });
+          it(`Does not allow outbidding a ${reservePrice} ETH bid`, async () => {
+            await expect(bidThroughParty(partyBid, signers[0])).to.be.reverted;
+          });
         });
+      });
     });
+  });
 });

--- a/test/custom/NFTBurned.test.js
+++ b/test/custom/NFTBurned.test.js
@@ -4,146 +4,141 @@ const { waffle } = require('hardhat');
 const { provider } = waffle;
 const { expect } = require('chai');
 // ============ Internal Imports ============
+const { eth, contribute, getBalances } = require('../helpers/utils');
 const {
-    eth,
-    contribute,
-    getBalances,
-} = require('../helpers/utils');
-const { placeBid, externalFinalize } = require('../helpers/externalTransactions');
+  placeBid,
+  externalFinalize,
+} = require('../helpers/externalTransactions');
 const { deployTestContractSetup, getTokenVault } = require('../helpers/deploy');
-const {
-    PARTY_STATUS,
-    FOURTY_EIGHT_HOURS_IN_SECONDS,
-} = require('../helpers/constants');
+const { PARTY_STATUS, SEVEN_DAYS_IN_SECONDS } = require('../helpers/constants');
 const { MARKETS } = require('../helpers/constants');
 
 describe('NFT Burned', async () => {
-    MARKETS.map((marketName) => {
-        describe(marketName, async () => {
-            // instantiate test vars
-            let partyBid,
-                market,
-                nftContract,
-                partyDAOMultisig,
-                auctionId,
-                multisigBalanceBefore,
-                token;
-            const signers = provider.getWallets();
-            const tokenId = 95;
-            const reservePrice = 100;
-            const totalContributed = 500;
+  MARKETS.map((marketName) => {
+    describe(marketName, async () => {
+      // instantiate test vars
+      let partyBid,
+        market,
+        nftContract,
+        partyDAOMultisig,
+        auctionId,
+        multisigBalanceBefore,
+        token;
+      const signers = provider.getWallets();
+      const tokenId = 95;
+      const reservePrice = 100;
+      const totalContributed = 500;
 
-            before(async () => {
+      before(async () => {
+        // DEPLOY NFT, MARKET, AND PARTY BID CONTRACTS
+        const contracts = await deployTestContractSetup(
+          marketName,
+          provider,
+          signers[0],
+          tokenId,
+          reservePrice,
+        );
+        partyBid = contracts.partyBid;
+        market = contracts.market;
+        partyDAOMultisig = contracts.partyDAOMultisig;
+        nftContract = contracts.nftContract;
 
-                // DEPLOY NFT, MARKET, AND PARTY BID CONTRACTS
-                const contracts = await deployTestContractSetup(
-                    marketName,
-                    provider,
-                    signers[0],
-                    tokenId,
-                    reservePrice,
-                );
-                partyBid = contracts.partyBid;
-                market = contracts.market;
-                partyDAOMultisig = contracts.partyDAOMultisig;
-                nftContract = contracts.nftContract;
+        auctionId = await partyBid.auctionId();
 
-                auctionId = await partyBid.auctionId();
+        multisigBalanceBefore = await provider.getBalance(
+          partyDAOMultisig.address,
+        );
 
-                multisigBalanceBefore = await provider.getBalance(
-                    partyDAOMultisig.address,
-                );
+        // submit contribution before bidding begins
+        await contribute(partyBid, signers[1], eth(totalContributed));
 
+        // place external bid
+        await placeBid(
+          signers[0],
+          market,
+          auctionId,
+          eth(reservePrice),
+          marketName,
+        );
+      });
 
-                // submit contribution before bidding begins
-                await contribute(partyBid, signers[1], eth(totalContributed));
+      it('Accepts external Finalize', async () => {
+        // increase time on-chain so that auction can be finalized
+        await provider.send('evm_increaseTime', [SEVEN_DAYS_IN_SECONDS]);
+        await provider.send('evm_mine');
 
-                // place external bid
-                await placeBid(
-                    signers[0],
-                    market,
-                    auctionId,
-                    eth(reservePrice),
-                    marketName,
-                );
-            });
+        await externalFinalize(signers[2], market, auctionId, marketName);
+      });
 
-            it('Accepts external Finalize', async () => {
-                // increase time on-chain so that auction can be finalized
-                await provider.send('evm_increaseTime', [
-                    FOURTY_EIGHT_HOURS_IN_SECONDS,
-                ]);
-                await provider.send('evm_mine');
+      it('Allows the owner to burn the NFT', async () => {
+        // burn the NFT
+        await expect(nftContract.burn(tokenId)).to.not.be.reverted;
+      });
 
-                await externalFinalize(signers[2], market, auctionId, marketName)
-            });
+      it('Is ACTIVE before PartyBid-level Finalize', async () => {
+        const partyStatus = await partyBid.partyStatus();
+        expect(partyStatus).to.equal(PARTY_STATUS.AUCTION_ACTIVE);
+      });
 
+      it('Allows PartyBid Finalize after auction-level Finalize & NFT burn', async () => {
+        // finalize auction
+        await expect(partyBid.finalize()).to.emit(partyBid, 'Finalized');
 
-            it('Allows the owner to burn the NFT', async () => {
-                // burn the NFT
-                await expect(nftContract.burn(tokenId)).to.not.be.reverted;
-            });
+        token = await getTokenVault(partyBid, signers[0]);
+      });
 
-            it('Is ACTIVE before PartyBid-level Finalize', async () => {
-                const partyStatus = await partyBid.partyStatus();
-                expect(partyStatus).to.equal(PARTY_STATUS.AUCTION_ACTIVE);
-            });
+      it(`Is LOST after Finalize`, async () => {
+        const partyStatus = await partyBid.partyStatus();
+        expect(partyStatus).to.equal(PARTY_STATUS.AUCTION_LOST);
+      });
 
-            it('Allows PartyBid Finalize after auction-level Finalize & NFT burn', async () => {
-                // finalize auction
-                await expect(partyBid.finalize()).to.emit(partyBid, 'Finalized');
+      it('Has zero totalSpent', async () => {
+        const totalSpent = await partyBid.totalSpent();
+        expect(totalSpent).to.equal(0);
+      });
 
-                token = await getTokenVault(partyBid, signers[0]);
-            });
+      it(`Did not transfer fee to multisig`, async () => {
+        const multisigBalanceAfter = await provider.getBalance(
+          partyDAOMultisig.address,
+        );
+        expect(multisigBalanceAfter).to.equal(multisigBalanceBefore);
+      });
 
-            it(`Is LOST after Finalize`, async () => {
-                const partyStatus = await partyBid.partyStatus();
-                expect(partyStatus).to.equal(PARTY_STATUS.AUCTION_LOST);
-            });
+      it(`Allows Claim, transfers ETH and tokens to contributors after Finalize`, async () => {
+        const contributor = signers[1];
+        const accounts = [
+          {
+            name: 'partyBid',
+            address: partyBid.address,
+          },
+          {
+            name: 'contributor',
+            address: contributor.address,
+          },
+        ];
 
-            it('Has zero totalSpent', async () => {
-                const totalSpent = await partyBid.totalSpent();
-                expect(totalSpent).to.equal(0);
-            });
+        const before = await getBalances(provider, token, accounts);
 
-            it(`Did not transfer fee to multisig`, async () => {
-                const multisigBalanceAfter = await provider.getBalance(
-                    partyDAOMultisig.address,
-                );
-                expect(multisigBalanceAfter).to.equal(multisigBalanceBefore);
-            });
+        // claim succeeds; event is emitted
+        await expect(partyBid.claim(contributor.address))
+          .to.emit(partyBid, 'Claimed')
+          .withArgs(
+            contributor.address,
+            eth(totalContributed),
+            eth(totalContributed),
+            eth(0),
+          );
 
-            it(`Allows Claim, transfers ETH and tokens to contributors after Finalize`, async () => {
-                const contributor = signers[1];
-                const accounts = [
-                    {
-                        name: 'partyBid',
-                        address: partyBid.address,
-                    },
-                    {
-                        name: 'contributor',
-                        address: contributor.address,
-                    },
-                ];
+        const after = await getBalances(provider, token, accounts);
 
-                const before = await getBalances(provider, token, accounts);
-
-                // claim succeeds; event is emitted
-                await expect(partyBid.claim(contributor.address))
-                    .to.emit(partyBid, 'Claimed')
-                    .withArgs(
-                        contributor.address,
-                        eth(totalContributed),
-                        eth(totalContributed),
-                        eth(0),
-                    );
-
-                const after = await getBalances(provider, token, accounts);
-
-                // ETH was transferred from PartyBid to contributor
-                await expect(after.partyBid.eth).to.equal(before.partyBid.eth - totalContributed,);
-                await expect(after.contributor.eth).to.equal(before.contributor.eth + totalContributed,);
-            });
-        });
+        // ETH was transferred from PartyBid to contributor
+        await expect(after.partyBid.eth).to.equal(
+          before.partyBid.eth - totalContributed,
+        );
+        await expect(after.contributor.eth).to.equal(
+          before.contributor.eth + totalContributed,
+        );
+      });
     });
+  });
 });

--- a/test/custom/NFTDestructed.test.js
+++ b/test/custom/NFTDestructed.test.js
@@ -4,156 +4,152 @@ const { waffle } = require('hardhat');
 const { provider } = waffle;
 const { expect } = require('chai');
 // ============ Internal Imports ============
+const { eth, contribute, getBalances } = require('../helpers/utils');
 const {
-    eth,
-    contribute,
-    getBalances,
-} = require('../helpers/utils');
-const { placeBid, externalFinalize } = require('../helpers/externalTransactions');
+  placeBid,
+  externalFinalize,
+} = require('../helpers/externalTransactions');
 const { deployTestContractSetup, getTokenVault } = require('../helpers/deploy');
-const {
-    PARTY_STATUS,
-    FOURTY_EIGHT_HOURS_IN_SECONDS,
-} = require('../helpers/constants');
+const { PARTY_STATUS, SEVEN_DAYS_IN_SECONDS } = require('../helpers/constants');
 const { MARKETS, MARKET_NAMES } = require('../helpers/constants');
 
 describe('NFT Contract Self-Destructed', async () => {
-    // The Nouns NFT contract cannot self-destruct
-    MARKETS.filter(m => m !== MARKET_NAMES.NOUNS).map((marketName) => {
-        describe(marketName, async () => {
-            // instantiate test vars
-            let partyBid,
-                market,
-                nftContract,
-                partyDAOMultisig,
-                auctionId,
-                multisigBalanceBefore,
-                token;
-            const signers = provider.getWallets();
-            const tokenId = 95;
-            const reservePrice = 100;
-            const totalContributed = 500;
+  // The Nouns NFT contract cannot self-destruct
+  MARKETS.filter((m) => m !== MARKET_NAMES.NOUNS).map((marketName) => {
+    describe(marketName, async () => {
+      // instantiate test vars
+      let partyBid,
+        market,
+        nftContract,
+        partyDAOMultisig,
+        auctionId,
+        multisigBalanceBefore,
+        token;
+      const signers = provider.getWallets();
+      const tokenId = 95;
+      const reservePrice = 100;
+      const totalContributed = 500;
 
-            before(async () => {
+      before(async () => {
+        // DEPLOY NFT, MARKET, AND PARTY BID CONTRACTS
+        const contracts = await deployTestContractSetup(
+          marketName,
+          provider,
+          signers[0],
+          tokenId,
+          reservePrice,
+        );
+        partyBid = contracts.partyBid;
+        market = contracts.market;
+        partyDAOMultisig = contracts.partyDAOMultisig;
+        nftContract = contracts.nftContract;
 
-                // DEPLOY NFT, MARKET, AND PARTY BID CONTRACTS
-                const contracts = await deployTestContractSetup(
-                    marketName,
-                    provider,
-                    signers[0],
-                    tokenId,
-                    reservePrice,
-                );
-                partyBid = contracts.partyBid;
-                market = contracts.market;
-                partyDAOMultisig = contracts.partyDAOMultisig;
-                nftContract = contracts.nftContract;
+        auctionId = await partyBid.auctionId();
 
-                auctionId = await partyBid.auctionId();
+        multisigBalanceBefore = await provider.getBalance(
+          partyDAOMultisig.address,
+        );
 
-                multisigBalanceBefore = await provider.getBalance(
-                    partyDAOMultisig.address,
-                );
+        // submit contribution before bidding begins
+        await contribute(partyBid, signers[1], eth(totalContributed));
 
+        // place external bid
+        await placeBid(
+          signers[0],
+          market,
+          auctionId,
+          eth(reservePrice),
+          marketName,
+        );
+      });
 
-                // submit contribution before bidding begins
-                await contribute(partyBid, signers[1], eth(totalContributed));
+      it('Accepts external Finalize', async () => {
+        // increase time on-chain so that auction can be finalized
+        await provider.send('evm_increaseTime', [SEVEN_DAYS_IN_SECONDS]);
+        await provider.send('evm_mine');
 
-                // place external bid
-                await placeBid(
-                    signers[0],
-                    market,
-                    auctionId,
-                    eth(reservePrice),
-                    marketName,
-                );
-            });
+        await externalFinalize(signers[2], market, auctionId, marketName);
+      });
 
-            it('Accepts external Finalize', async () => {
-                // increase time on-chain so that auction can be finalized
-                await provider.send('evm_increaseTime', [
-                    FOURTY_EIGHT_HOURS_IN_SECONDS,
-                ]);
-                await provider.send('evm_mine');
+      it('Can query balanceOf before self-destruct', async () => {
+        // destruct the NFT contract
+        await expect(nftContract.ownerOf(tokenId)).to.not.be.reverted;
+      });
 
-                await externalFinalize(signers[2], market, auctionId, marketName)
-            });
+      it('Can self-destruct', async () => {
+        // destruct the NFT contract
+        await expect(nftContract.destruct()).to.not.be.reverted;
+      });
 
-            it('Can query balanceOf before self-destruct', async () => {
-                // destruct the NFT contract
-                await expect(nftContract.ownerOf(tokenId)).to.not.be.reverted;
-            });
+      it('Can query NOT balanceOf before self-destruct', async () => {
+        // destruct the NFT contract
+        await expect(nftContract.ownerOf(tokenId)).to.be.reverted;
+      });
 
-            it('Can self-destruct', async () => {
-                // destruct the NFT contract
-                await expect(nftContract.destruct()).to.not.be.reverted;
-            });
+      it('Is ACTIVE before PartyBid-level Finalize', async () => {
+        const partyStatus = await partyBid.partyStatus();
+        expect(partyStatus).to.equal(PARTY_STATUS.AUCTION_ACTIVE);
+      });
 
-            it('Can query NOT balanceOf before self-destruct', async () => {
-                // destruct the NFT contract
-                await expect(nftContract.ownerOf(tokenId)).to.be.reverted;
-            });
+      it('Allows PartyBid Finalize after auction-level Finalize & NFT burn', async () => {
+        // finalize auction
+        await expect(partyBid.finalize()).to.emit(partyBid, 'Finalized');
 
-            it('Is ACTIVE before PartyBid-level Finalize', async () => {
-                const partyStatus = await partyBid.partyStatus();
-                expect(partyStatus).to.equal(PARTY_STATUS.AUCTION_ACTIVE);
-            });
+        token = await getTokenVault(partyBid, signers[0]);
+      });
 
-            it('Allows PartyBid Finalize after auction-level Finalize & NFT burn', async () => {
-                // finalize auction
-                await expect(partyBid.finalize()).to.emit(partyBid, 'Finalized');
+      it(`Is LOST after Finalize`, async () => {
+        const partyStatus = await partyBid.partyStatus();
+        expect(partyStatus).to.equal(PARTY_STATUS.AUCTION_LOST);
+      });
 
-                token = await getTokenVault(partyBid, signers[0]);
-            });
+      it('Has zero totalSpent', async () => {
+        const totalSpent = await partyBid.totalSpent();
+        expect(totalSpent).to.equal(0);
+      });
 
-            it(`Is LOST after Finalize`, async () => {
-                const partyStatus = await partyBid.partyStatus();
-                expect(partyStatus).to.equal(PARTY_STATUS.AUCTION_LOST);
-            });
+      it(`Did not transfer fee to multisig`, async () => {
+        const multisigBalanceAfter = await provider.getBalance(
+          partyDAOMultisig.address,
+        );
+        expect(multisigBalanceAfter).to.equal(multisigBalanceBefore);
+      });
 
-            it('Has zero totalSpent', async () => {
-                const totalSpent = await partyBid.totalSpent();
-                expect(totalSpent).to.equal(0);
-            });
+      it(`Allows Claim, transfers ETH and tokens to contributors after Finalize`, async () => {
+        const contributor = signers[1];
+        const accounts = [
+          {
+            name: 'partyBid',
+            address: partyBid.address,
+          },
+          {
+            name: 'contributor',
+            address: contributor.address,
+          },
+        ];
 
-            it(`Did not transfer fee to multisig`, async () => {
-                const multisigBalanceAfter = await provider.getBalance(
-                    partyDAOMultisig.address,
-                );
-                expect(multisigBalanceAfter).to.equal(multisigBalanceBefore);
-            });
+        const before = await getBalances(provider, token, accounts);
 
-            it(`Allows Claim, transfers ETH and tokens to contributors after Finalize`, async () => {
-                const contributor = signers[1];
-                const accounts = [
-                    {
-                        name: 'partyBid',
-                        address: partyBid.address,
-                    },
-                    {
-                        name: 'contributor',
-                        address: contributor.address,
-                    },
-                ];
+        // claim succeeds; event is emitted
+        await expect(partyBid.claim(contributor.address))
+          .to.emit(partyBid, 'Claimed')
+          .withArgs(
+            contributor.address,
+            eth(totalContributed),
+            eth(totalContributed),
+            eth(0),
+          );
 
-                const before = await getBalances(provider, token, accounts);
+        const after = await getBalances(provider, token, accounts);
 
-                // claim succeeds; event is emitted
-                await expect(partyBid.claim(contributor.address))
-                    .to.emit(partyBid, 'Claimed')
-                    .withArgs(
-                        contributor.address,
-                        eth(totalContributed),
-                        eth(totalContributed),
-                        eth(0),
-                    );
-
-                const after = await getBalances(provider, token, accounts);
-
-                // ETH was transferred from PartyBid to contributor
-                await expect(after.partyBid.eth).to.equal(before.partyBid.eth - totalContributed,);
-                await expect(after.contributor.eth).to.equal(before.contributor.eth + totalContributed,);
-            });
-        });
+        // ETH was transferred from PartyBid to contributor
+        await expect(after.partyBid.eth).to.equal(
+          before.partyBid.eth - totalContributed,
+        );
+        await expect(after.contributor.eth).to.equal(
+          before.contributor.eth + totalContributed,
+        );
+      });
     });
+  });
 });

--- a/test/custom/TransferWETH.test.js
+++ b/test/custom/TransferWETH.test.js
@@ -7,139 +7,132 @@ const { expect } = require('chai');
 const { eth, getBalances } = require('../helpers/utils');
 const { placeBid } = require('../helpers/externalTransactions');
 const { deployTestContractSetup, deploy } = require('../helpers/deploy');
-const {
-    MARKETS,
-    FOURTY_EIGHT_HOURS_IN_SECONDS,
-} = require('../helpers/constants');
+const { MARKETS, SEVEN_DAYS_IN_SECONDS } = require('../helpers/constants');
 
 describe('Transfer WETH', async () => {
-    MARKETS.map((marketName) => {
-        describe(marketName, async () => {
-            // instantiate test vars
-            let partyBid, token, nonPayable, accounts;
-            const contributionAmount = 1;
+  MARKETS.map((marketName) => {
+    describe(marketName, async () => {
+      // instantiate test vars
+      let partyBid, token, nonPayable, accounts;
+      const contributionAmount = 1;
 
-            before(async () => {
-                const signers = provider.getWallets();
+      before(async () => {
+        const signers = provider.getWallets();
 
-                // DEPLOY NFT, MARKET, AND PARTY BID CONTRACTS
-                const contracts = await deployTestContractSetup(
-                    marketName,
-                    provider,
-                    signers[0],
-                    95,
-                    1,
-                );
-                partyBid = contracts.partyBid;
-                token = contracts.weth;
+        // DEPLOY NFT, MARKET, AND PARTY BID CONTRACTS
+        const contracts = await deployTestContractSetup(
+          marketName,
+          provider,
+          signers[0],
+          95,
+          1,
+        );
+        partyBid = contracts.partyBid;
+        token = contracts.weth;
 
-                const auctionId = await partyBid.auctionId();
+        const auctionId = await partyBid.auctionId();
 
-                // place bid from signer to kick off auction
-                await placeBid(
-                    signers[0],
-                    contracts.market,
-                    auctionId,
-                    eth(1),
-                    marketName,
-                );
+        // place bid from signer to kick off auction
+        await placeBid(
+          signers[0],
+          contracts.market,
+          auctionId,
+          eth(1),
+          marketName,
+        );
 
-                // deploy payable contract and send ETH to it
-                const payable = await deploy("PayableContract");
-                await signers[0].sendTransaction({
-                    value: eth(contributionAmount),
-                    to: payable.address
-                });
-
-                // deploy non-payable contract
-                nonPayable = await deploy("NonPayableContract");
-
-                // destruct payable contract, sending ETH to non-payable
-                await payable.destruct(nonPayable.address);
-
-                // instantiate balances of addresses before
-                accounts = [
-                    {
-                        name: 'partyBid',
-                        address: partyBid.address,
-                    },
-                    {
-                        name: 'nonPayable',
-                        address: nonPayable.address,
-                    },
-                ];
-
-            });
-
-            it('Has correct balances before contribute', async () => {
-                const balances = await getBalances(provider, token, accounts);
-                // partyBid has ETH before contribute
-                expect(balances.partyBid.eth).to.equal(0);
-                // partyBid has no WETH before contribute
-                expect(balances.partyBid.tokens).to.equal(0);
-
-                // contributor has ETH before contribute
-                expect(balances.nonPayable.eth).to.equal(contributionAmount);
-                // contributor has no WETH before contribute
-                expect(balances.nonPayable.tokens).to.equal(0);
-            });
-
-            it('Accepts contribution from contract', async () => {
-                // submit contribution from non-payable contract
-                await expect(nonPayable.contribute(partyBid.address, eth(contributionAmount))).to.emit(
-                    partyBid,
-                    'Contributed',
-                );
-            });
-
-            it('Has correct balances after contribute, before claim', async () => {
-                const balances = await getBalances(provider, token, accounts);
-                // partyBid has ETH after contribute, before claim
-                expect(balances.partyBid.eth).to.equal(contributionAmount);
-                // partyBid has no WETH after contribute, before claim
-                expect(balances.partyBid.tokens).to.equal(0);
-
-                // contributor has ETH after contribute, before claim
-                expect(balances.nonPayable.eth).to.equal(0);
-                // contributor has no WETH after contribute, before claim
-                expect(balances.nonPayable.tokens).to.equal(0);
-            });
-
-            it('Allows Finalize', async () => {
-                // increase time on-chain so that auction can be finalized
-                await provider.send('evm_increaseTime', [
-                    FOURTY_EIGHT_HOURS_IN_SECONDS,
-                ]);
-                await provider.send('evm_mine');
-
-                // finalize auction
-                await expect(partyBid.finalize()).to.emit(partyBid, 'Finalized');
-            });
-
-            it('Allows Claim', async () => {
-                // claim succeeds; event is emitted
-                await expect(partyBid.claim(nonPayable.address))
-                    .to.emit(partyBid, 'Claimed')
-                    .withArgs(
-                        nonPayable.address,
-                        eth(contributionAmount),
-                        eth(contributionAmount),
-                        eth(0),
-                    );
-            });
-
-            it('Has correct balances after claim', async () => {
-                const balances = await getBalances(provider, token, accounts);
-                // partyBid has ETH after contribute, before claim
-                expect(balances.partyBid.eth).to.equal(0);
-                // partyBid has no WETH after contribute, before claim
-                expect(balances.partyBid.tokens).to.equal(0);
-
-                // contributor has ETH after contribute, before claim
-                expect(balances.nonPayable.eth).to.equal(0);
-                // contributor has no WETH after contribute, before claim
-                expect(balances.nonPayable.tokens).to.equal(contributionAmount);
-            });
+        // deploy payable contract and send ETH to it
+        const payable = await deploy('PayableContract');
+        await signers[0].sendTransaction({
+          value: eth(contributionAmount),
+          to: payable.address,
         });
+
+        // deploy non-payable contract
+        nonPayable = await deploy('NonPayableContract');
+
+        // destruct payable contract, sending ETH to non-payable
+        await payable.destruct(nonPayable.address);
+
+        // instantiate balances of addresses before
+        accounts = [
+          {
+            name: 'partyBid',
+            address: partyBid.address,
+          },
+          {
+            name: 'nonPayable',
+            address: nonPayable.address,
+          },
+        ];
+      });
+
+      it('Has correct balances before contribute', async () => {
+        const balances = await getBalances(provider, token, accounts);
+        // partyBid has ETH before contribute
+        expect(balances.partyBid.eth).to.equal(0);
+        // partyBid has no WETH before contribute
+        expect(balances.partyBid.tokens).to.equal(0);
+
+        // contributor has ETH before contribute
+        expect(balances.nonPayable.eth).to.equal(contributionAmount);
+        // contributor has no WETH before contribute
+        expect(balances.nonPayable.tokens).to.equal(0);
+      });
+
+      it('Accepts contribution from contract', async () => {
+        // submit contribution from non-payable contract
+        await expect(
+          nonPayable.contribute(partyBid.address, eth(contributionAmount)),
+        ).to.emit(partyBid, 'Contributed');
+      });
+
+      it('Has correct balances after contribute, before claim', async () => {
+        const balances = await getBalances(provider, token, accounts);
+        // partyBid has ETH after contribute, before claim
+        expect(balances.partyBid.eth).to.equal(contributionAmount);
+        // partyBid has no WETH after contribute, before claim
+        expect(balances.partyBid.tokens).to.equal(0);
+
+        // contributor has ETH after contribute, before claim
+        expect(balances.nonPayable.eth).to.equal(0);
+        // contributor has no WETH after contribute, before claim
+        expect(balances.nonPayable.tokens).to.equal(0);
+      });
+
+      it('Allows Finalize', async () => {
+        // increase time on-chain so that auction can be finalized
+        await provider.send('evm_increaseTime', [SEVEN_DAYS_IN_SECONDS]);
+        await provider.send('evm_mine');
+
+        // finalize auction
+        await expect(partyBid.finalize()).to.emit(partyBid, 'Finalized');
+      });
+
+      it('Allows Claim', async () => {
+        // claim succeeds; event is emitted
+        await expect(partyBid.claim(nonPayable.address))
+          .to.emit(partyBid, 'Claimed')
+          .withArgs(
+            nonPayable.address,
+            eth(contributionAmount),
+            eth(contributionAmount),
+            eth(0),
+          );
+      });
+
+      it('Has correct balances after claim', async () => {
+        const balances = await getBalances(provider, token, accounts);
+        // partyBid has ETH after contribute, before claim
+        expect(balances.partyBid.eth).to.equal(0);
+        // partyBid has no WETH after contribute, before claim
+        expect(balances.partyBid.tokens).to.equal(0);
+
+        // contributor has ETH after contribute, before claim
+        expect(balances.nonPayable.eth).to.equal(0);
+        // contributor has no WETH after contribute, before claim
+        expect(balances.nonPayable.tokens).to.equal(contributionAmount);
+      });
     });
+  });
 });

--- a/test/helpers/constants.js
+++ b/test/helpers/constants.js
@@ -1,13 +1,14 @@
-const FOURTY_EIGHT_HOURS_IN_SECONDS = 48 * 60 * 60;
+const SEVEN_DAYS_IN_SECONDS = 7 * 24 * 60 * 60;
 
 const MARKET_NAMES = {
   ZORA: 'ZORA',
   FOUNDATION: 'FOUNDATION',
   NOUNS: 'NOUNS',
+  FRACTIONAL: 'FRACTIONAL',
 };
 
 // MARKETS is an array of all values in MARKET_NAMES
-const MARKETS = Object.keys(MARKET_NAMES).map(key => MARKET_NAMES[key]);
+const MARKETS = Object.keys(MARKET_NAMES).map((key) => MARKET_NAMES[key]);
 
 const NFT_TYPE_ENUM = {
   ZORA: 0,
@@ -30,5 +31,5 @@ module.exports = {
   NFT_TYPE_ENUM,
   ONE_ETH,
   PARTY_STATUS,
-  FOURTY_EIGHT_HOURS_IN_SECONDS,
+  SEVEN_DAYS_IN_SECONDS,
 };

--- a/test/helpers/externalTransactions.js
+++ b/test/helpers/externalTransactions.js
@@ -2,60 +2,74 @@ const { encodeData } = require('./utils');
 const { MARKET_NAMES } = require('./constants');
 
 async function placeBid(signer, marketContract, auctionId, value, marketName) {
-    let data;
-    if (marketName == MARKET_NAMES.ZORA) {
-        data = encodeData(marketContract, 'createBid', [auctionId, value]);
-    } else if (marketName == MARKET_NAMES.NOUNS) {
-        data = encodeData(marketContract, 'createBid', [auctionId]);
-    } else if(marketName == MARKET_NAMES.FOUNDATION) {
-        data = encodeData(marketContract, 'placeBid', [auctionId]);
+  let data;
+  if (marketName == MARKET_NAMES.ZORA) {
+    data = encodeData(marketContract, 'createBid', [auctionId, value]);
+  } else if (marketName == MARKET_NAMES.NOUNS) {
+    data = encodeData(marketContract, 'createBid', [auctionId]);
+  } else if (marketName == MARKET_NAMES.FOUNDATION) {
+    data = encodeData(marketContract, 'placeBid', [auctionId]);
+  } else if (marketName == MARKET_NAMES.FRACTIONAL) {
+    const auctionState = await marketContract.auctionState();
+    if (auctionState === 0) {
+      data = encodeData(marketContract, 'start', []);
     } else {
-        throw new Error("Unsupported Market");
+      data = encodeData(marketContract, 'bid', []);
     }
+  } else {
+    throw new Error('Unsupported Market');
+  }
 
-    return signer.sendTransaction({
-        to: marketContract.address,
-        data,
-        value,
-    });
+  return signer.sendTransaction({
+    to: marketContract.address,
+    data,
+    value,
+  });
 }
 
 async function externalFinalize(signer, marketContract, auctionId, marketName) {
-    let data;
-    if (marketName == MARKET_NAMES.ZORA) {
-        data = encodeData(marketContract, 'endAuction', [auctionId]);
-    } else if (marketName == MARKET_NAMES.NOUNS) {
-        data = encodeData(marketContract, 'settleCurrentAndCreateNewAuction', []);
-    } else if(marketName == MARKET_NAMES.FOUNDATION) {
-        data = encodeData(marketContract, 'finalizeReserveAuction', [auctionId]);
-    } else {
-        throw new Error("Unsupported Market");
-    }
+  let data;
+  if (marketName == MARKET_NAMES.ZORA) {
+    data = encodeData(marketContract, 'endAuction', [auctionId]);
+  } else if (marketName == MARKET_NAMES.NOUNS) {
+    data = encodeData(marketContract, 'settleCurrentAndCreateNewAuction', []);
+  } else if (marketName == MARKET_NAMES.FOUNDATION) {
+    data = encodeData(marketContract, 'finalizeReserveAuction', [auctionId]);
+  } else if (marketName == MARKET_NAMES.FRACTIONAL) {
+    data = encodeData(marketContract, 'end', []);
+  } else {
+    throw new Error('Unsupported Market');
+  }
 
-    return signer.sendTransaction({
-        to: marketContract.address,
-        data,
-    });
+  return signer.sendTransaction({
+    to: marketContract.address,
+    data,
+  });
 }
 
-async function cancelAuction(artistSigner, marketContract, auctionId, marketName) {
-    let data;
-    if (marketName == MARKET_NAMES.ZORA) {
-        data = encodeData(marketContract, 'cancelAuction', [auctionId]);
-    } else if(marketName == MARKET_NAMES.FOUNDATION) {
-        data = encodeData(marketContract, 'cancelReserveAuction', [auctionId]);
-    } else {
-        throw new Error("Unsupported Market");
-    }
+async function cancelAuction(
+  artistSigner,
+  marketContract,
+  auctionId,
+  marketName,
+) {
+  let data;
+  if (marketName == MARKET_NAMES.ZORA) {
+    data = encodeData(marketContract, 'cancelAuction', [auctionId]);
+  } else if (marketName == MARKET_NAMES.FOUNDATION) {
+    data = encodeData(marketContract, 'cancelReserveAuction', [auctionId]);
+  } else {
+    throw new Error('Unsupported Market');
+  }
 
-    return artistSigner.sendTransaction({
-        to: marketContract.address,
-        data,
-    });
+  return artistSigner.sendTransaction({
+    to: marketContract.address,
+    data,
+  });
 }
 
 module.exports = {
-    placeBid,
-    externalFinalize,
-    cancelAuction
+  placeBid,
+  externalFinalize,
+  cancelAuction,
 };

--- a/test/helpers/utils.js
+++ b/test/helpers/utils.js
@@ -1,5 +1,5 @@
 const { expect } = require('chai');
-const { FOURTY_EIGHT_HOURS_IN_SECONDS, MARKET_NAMES } = require('./constants');
+const { SEVEN_DAYS_IN_SECONDS, MARKET_NAMES } = require('./constants');
 
 function eth(num) {
   return ethers.utils.parseEther(num.toString());
@@ -22,10 +22,8 @@ async function getBalances(provider, token, accounts) {
       weiToEth(await provider.getBalance(address)),
     );
     let tokenBalance = 0;
-    if(token && token.address != ethers.constants.AddressZero) {
-      tokenBalance = parseFloat(
-          weiToEth(await token.balanceOf(address)),
-      );
+    if (token && token.address != ethers.constants.AddressZero) {
+      tokenBalance = parseFloat(weiToEth(await token.balanceOf(address)));
     }
     balances[name]['tokens'] = tokenBalance;
   }
@@ -77,8 +75,16 @@ async function emergencyWithdrawEth(partyBidContract, signer, value) {
   });
 }
 
-async function emergencyCall(partyBidContract, signer, contractAddress, calldata) {
-  const data = encodeData(partyBidContract, 'emergencyCall', [contractAddress, calldata]);
+async function emergencyCall(
+  partyBidContract,
+  signer,
+  contractAddress,
+  calldata,
+) {
+  const data = encodeData(partyBidContract, 'emergencyCall', [
+    contractAddress,
+    calldata,
+  ]);
 
   return signer.sendTransaction({
     to: partyBidContract.address,
@@ -87,7 +93,7 @@ async function emergencyCall(partyBidContract, signer, contractAddress, calldata
 }
 
 async function emergencyForceLost(partyBidContract, signer) {
-  const data = encodeData(partyBidContract, 'emergencyForceLost',);
+  const data = encodeData(partyBidContract, 'emergencyForceLost');
 
   return signer.sendTransaction({
     to: partyBidContract.address,
@@ -141,7 +147,7 @@ async function createZoraAuction(
   tokenId,
   tokenContractAddress,
   reservePrice,
-  duration = FOURTY_EIGHT_HOURS_IN_SECONDS,
+  duration = SEVEN_DAYS_IN_SECONDS,
   curatorFeePercentage = 0,
 ) {
   const data = encodeData(marketContract, 'createAuction', [

--- a/test/testCases.json
+++ b/test/testCases.json
@@ -55,12 +55,14 @@
       "finalBid": {
         "ZORA": 1.575,
         "FOUNDATION": 1.65,
-        "NOUNS": 1.575
+        "NOUNS": 1.575,
+        "FRACTIONAL": 1.575
       },
       "finalFee": {
         "ZORA": 0.07875,
         "FOUNDATION": 0.0825,
-        "NOUNS": 0.07875
+        "NOUNS": 0.07875,
+        "FRACTIONAL": 0.07875
       },
       "claims": {
         "ZORA": [
@@ -104,7 +106,21 @@
             "excessEth": 1,
             "totalContributed": 2.5
           }
-        ]
+        ],
+        "FRACTIONAL": [
+            {
+              "signerIndex": 1,
+              "tokens": 153.75,
+              "excessEth": 2.34625,
+              "totalContributed": 2.5
+            },
+            {
+              "signerIndex": 0,
+              "tokens": 1500,
+              "excessEth": 1,
+              "totalContributed": 2.5
+            }
+          ]
       }
     },
     {
@@ -145,12 +161,14 @@
       "finalBid": {
         "ZORA": 10.5,
         "FOUNDATION": 11,
-        "NOUNS": 10.5
+        "NOUNS": 10.5,
+        "FRACTIONAL": 10.5
       },
       "finalFee": {
         "ZORA": 0.525,
         "FOUNDATION": 0.55,
-        "NOUNS": 0.525
+        "NOUNS": 0.525,
+        "FRACTIONAL": 0.525
       },
       "claims": {
         "ZORA": [
@@ -194,7 +212,21 @@
             "excessEth": 88.975,
             "totalContributed": 94.5
           }
-        ]
+        ],
+        "FRACTIONAL": [
+            {
+              "signerIndex": 0,
+              "tokens": 5500,
+              "excessEth": 0,
+              "totalContributed": 5.5
+            },
+            {
+              "signerIndex": 1,
+              "tokens": 5525,
+              "excessEth": 88.975,
+              "totalContributed": 94.5
+            }
+          ]
       }
     },
     {
@@ -223,12 +255,14 @@
       "finalBid": {
         "ZORA": 0,
         "FOUNDATION": 0,
-        "NOUNS": 0
+        "NOUNS": 0,
+        "FRACTIONAL": 0
       },
       "finalFee": {
         "ZORA": 0,
         "FOUNDATION": 0,
-        "NOUNS": 0
+        "NOUNS": 0,
+        "FRACTIONAL": 0
       },
       "claims": {
         "ZORA": [
@@ -272,7 +306,21 @@
             "excessEth": 5,
             "totalContributed": 5
           }
-        ]
+        ],
+        "FRACTIONAL": [
+            {
+              "signerIndex": 1,
+              "tokens": 0,
+              "excessEth": 5,
+              "totalContributed": 5
+            },
+            {
+              "signerIndex": 0,
+              "tokens": 0,
+              "excessEth": 5,
+              "totalContributed": 5
+            }
+          ]
       }
     },
     {
@@ -305,12 +353,14 @@
       "finalBid": {
         "ZORA": 10.5,
         "FOUNDATION": 11,
-        "NOUNS": 10.5
+        "NOUNS": 10.5,
+        "FRACTIONAL": 10.5
       },
       "finalFee": {
         "ZORA": 0.525,
         "FOUNDATION": 0.55,
-        "NOUNS": 0.525
+        "NOUNS": 0.525,
+        "FRACTIONAL": 0.525
       },
       "claims": {
         "ZORA": [
@@ -354,7 +404,21 @@
             "excessEth": 10,
             "totalContributed": 10
           }
-        ]
+        ],
+        "FRACTIONAL": [
+            {
+              "signerIndex": 0,
+              "tokens": 11025,
+              "excessEth": 0.525,
+              "totalContributed": 11.55
+            },
+            {
+              "signerIndex": 1,
+              "tokens": 0,
+              "excessEth": 10,
+              "totalContributed": 10
+            }
+          ]
       }
     },
     {
@@ -379,12 +443,14 @@
       "finalBid": {
         "ZORA": 1.05,
         "FOUNDATION": 1.1,
-        "NOUNS": 1.05
+        "NOUNS": 1.05,
+        "FRACTIONAL": 1.05
       },
       "finalFee": {
         "ZORA": 0.0525,
         "FOUNDATION": 0.055,
-        "NOUNS": 0.0525
+        "NOUNS": 0.0525,
+        "FRACTIONAL": 0.0525
       },
       "claims": {
         "ZORA": [
@@ -410,6 +476,14 @@
             "excessEth": 0.8975,
             "totalContributed": 2
           }
+        ],
+        "FRACTIONAL": [
+            {
+                "signerIndex": 1,
+                "tokens": 1102.5,
+                "excessEth": 0.8975,
+                "totalContributed": 2
+            }
         ]
       }
     }


### PR DESCRIPTION
Built the MarketWrapper contract for Fractional Auctions along with its unit tests.

**Current issue:** In case of a losing bid, fractional vault transfers ETH to EOA but WETH for contract addresses.\
As PartyBid expects the payout to be in ETH, the following test cases fail:

```
Claim
    Allows Claim, transfers ETH and tokens to contributors after Finalize
Emergency Force Lost
    ETH balance is equal to total contributed to party
    Allows Claim, transfers ETH and tokens to contributors after Finalize
External Finalize    
    Has correct totalSpent, totalSupply of tokens, balanceOf PartyBid tokens, and ETH balance
Finalize
    Has correct totalSpent, totalSupply of tokens, balanceOf PartyBid tokens, and ETH balance
```

Thinking about the possible solutions:
1. Fractional allows ETH transfers to contracts. Or have some whitelist if they don't trust all contracts.
2. PartyBid adds support for WETH in `finalize()`
3. Any other way? Pls suggest.