### PR TITLE
Add indexing for events

### DIFF
--- a/contracts/CollectionPartyFactory.sol
+++ b/contracts/CollectionPartyFactory.sol
@@ -13,9 +13,9 @@ contract CollectionPartyFactory {
     //======== Events ========
 
     event CollectionPartyDeployed(
-        address partyProxy,
-        address creator,
-        address nftContract,
+        address indexed partyProxy,
+        address indexed creator,
+        address indexed nftContract,
         uint256 maxPrice,
         uint256 secondsToTimeout,
         address[] deciders,

--- a/contracts/PartyBidFactory.sol
+++ b/contracts/PartyBidFactory.sol
@@ -18,9 +18,9 @@ contract PartyBidFactory {
     //======== Events ========
 
     event PartyBidDeployed(
-        address partyBidProxy,
-        address creator,
-        address nftContract,
+        address indexed partyBidProxy,
+        address indexed creator,
+        address indexed nftContract,
         uint256 tokenId,
         address marketWrapper,
         uint256 auctionId,

--- a/contracts/PartyBuyFactory.sol
+++ b/contracts/PartyBuyFactory.sol
@@ -13,9 +13,9 @@ contract PartyBuyFactory {
     //======== Events ========
 
     event PartyBuyDeployed(
-        address partyProxy,
-        address creator,
-        address nftContract,
+        address indexed partyProxy,
+        address indexed creator,
+        address indexed nftContract,
         uint256 tokenId,
         uint256 maxPrice,
         uint256 secondsToTimeout,


### PR DESCRIPTION
Our frontend needs partyProxy to be indexed so we can filter for the deployment of the CollectionBuy to get the deciders.  I've also added indexing to the other contract deployments and the creator and nftContract properties as well, figuring that its a nominal increase in gas at deployment for a good deal of flexibility on our front-end.

In reference to https://github.com/PartyDAO/partybuy/pull/4#discussion_r783577182