### PR TITLE
Fix test

### DIFF
--- a/test/PartyBid/Deploy.test.js
+++ b/test/PartyBid/Deploy.test.js
@@ -8,7 +8,7 @@ const { eth } = require('../helpers/utils');
 const { deployTestContractSetup } = require('../helpers/deploy');
 const { MARKETS, PARTY_STATUS } = require('../helpers/constants');
 
-describe('Deploy', async () => {
+describe('Deploy PartyBid', async () => {
   MARKETS.map((marketName) => {
     describe(marketName, async () => {
       const splitRecipient = '0x0000000000000000000000000000000000000000';
@@ -67,6 +67,7 @@ describe('Deploy', async () => {
             ['0x0000000000000000000000000000000000000000', 0],
             'PartyBid Logic',
             'LOGIC',
+            6000
           ),
         ).to.be.revertedWith('Party::__Party_init: only factory can init');
       });

--- a/test/PartyBuy/Deploy.test.js
+++ b/test/PartyBuy/Deploy.test.js
@@ -11,7 +11,7 @@ const {
   FOURTY_EIGHT_HOURS_IN_SECONDS,
 } = require('./helpers/constants');
 
-describe('Deploy', async () => {
+describe('Deploy PartyBuy', async () => {
   const splitRecipient = '0x0000000000000000000000000000000000000000';
   const splitBasisPoints = 0;
   const maxPrice = 10;


### PR DESCRIPTION
A test broke during the big merge so this fixes it by adding the missing expiration time, and renames some tests that had the same name to be more clear where the failure was coming from